### PR TITLE
[master] Bundle-SymbolicName fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.5</version>
     </parent>
 
     <groupId>jakarta.ejb</groupId>
@@ -104,7 +104,7 @@
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>spec-version-maven-plugin</artifactId>
-                    <version>1.5</version>
+                    <version>2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.build</groupId>


### PR DESCRIPTION
 - version of spec-version-maven-plugin updated to 2.0
 - parent version updated to 1.0.5

I modified spec-version-maven-plugin to generate Bundle-SymbolicName with jakarta prefix when working in jakarta specMode.
See https://github.com/eclipse-ee4j/glassfish-spec-version-maven-plugin/pull/6 for details.
spec-version-maven-plugin with this change was released into OSSRH staging repo as version 2.0 and will go into Maven Central together with other EE4J components.
