### PR TITLE
[EE4J_8] Bundle-SymbolicName fix:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
     </parent>
 
     <groupId>jakarta.ejb</groupId>
@@ -104,7 +104,7 @@
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>spec-version-maven-plugin</artifactId>
-                    <version>1.5</version>
+                    <version>2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.build</groupId>


### PR DESCRIPTION
 - version of spec-version-maven-plugin updated to 2.0
 - parent version updated to 1.0.5

See https://github.com/eclipse-ee4j/ejb-api/pull/30 for details.
EE4J_8 build job was fixed too.