### PR TITLE
Replaced EJB with enterprise beans or Jakarta Enterprise Beans

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to Eclipse Project for EJB
+# Contributing to Jakarta Enterprise Beans
 
 Thanks for your interest in this project.
 
 ## Project description
 
-Enterprise JavaBeans is an architecture for the development and deployment of
+Jakarta Enterprise Beans is an architecture for the development and deployment of
 component-based business applications.
 
 * https://projects.eclipse.org/projects/ee4j.ejb

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,12 +1,12 @@
-# Notices for Eclipse Project for EJB
+# Notices for Jakarta Enterprise Beans
 
-This content is produced and maintained by the Eclipse Project for EJB project.
+This content is produced and maintained by the Jakarta Enterprise Beans project.
 
 * Project home: https://projects.eclipse.org/projects/ee4j.ejb
 
 ## Trademarks
 
-Eclipse Project for EJB is a trademark of the Eclipse Foundation.
+Jakarta Enterprise Beans is a trademark of the Eclipse Foundation.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# EJB API
+# Jakarta Enterprise Beans API
 
-This is the repository for EJB API.
+This is the repository for Jakarta Enterprise Beans API.
 
 ## Build
 

--- a/api/src/main/java/javax/ejb/Asynchronous.java
+++ b/api/src/main/java/javax/ejb/Asynchronous.java
@@ -30,7 +30,7 @@ import static java.lang.annotation.RetentionPolicy.*;
  * <p>
  * Asynchronous method invocation semantics only apply to the no-interface, 
  * local business, and remote business client views.   Methods exposed 
- * through the EJB 2.x local, EJB 2.x remote, and web service client views 
+ * through the enterprise bean 2.x local, enterprise bean 2.x remote, and web service client views 
  * must not be designated as asynchronous.
  *
  * @see AsyncResult

--- a/api/src/main/java/javax/ejb/CreateException.java
+++ b/api/src/main/java/javax/ejb/CreateException.java
@@ -22,7 +22,7 @@ package javax.ejb;
  * interface. 
  *
  * <p> This exception is used as a standard application-level exception to
- * report a failure to create an EJB object or local object.
+ * report a failure to create an enterprise bean object or local object.
  *
  * @since EJB 1.0
  */

--- a/api/src/main/java/javax/ejb/DuplicateKeyException.java
+++ b/api/src/main/java/javax/ejb/DuplicateKeyException.java
@@ -18,11 +18,11 @@ package javax.ejb;
 
 /**
  * The DuplicateKeyException exception is thrown if an entity EJB
- * object or EJB local object cannot be created because an object with the
+ * object or enterprise bean local object cannot be created because an object with the
  * same key already exists.  This exception is thrown by the create
  * methods defined in an entity bean's home or local home interface.
  *
- * <p><b>Note:</b> Support for entity beans is optional as of EJB 3.2 
+ * <p><b>Note:</b> Support for entity beans is optional as of enterprise bean 3.2 
  *
  * @since EJB 1.0
  */

--- a/api/src/main/java/javax/ejb/EJB.java
+++ b/api/src/main/java/javax/ejb/EJB.java
@@ -26,23 +26,23 @@ import static java.lang.annotation.RetentionPolicy.*;
  * JavaBean.
  * <p>
  * Either the <code>beanName</code> or the <code>lookup</code> element can 
- * be used to resolve the EJB dependency to its target session bean component.  
+ * be used to resolve the enterprise bean dependency to its target session bean component.  
  * It is an error to specify values for both <code>beanName</code> and 
  * <code>lookup</code>.
  * <p>
  * If no explicit linking information is provided and there is only one session
  * bean within the same application that exposes the matching client view type,
- * by default the EJB dependency resolves to that session bean.
+ * by default the enterprise bean dependency resolves to that session bean.
  *
  * @since EJB 3.0
  */
 
 @Target({TYPE, METHOD, FIELD})
 @Retention(RUNTIME)
-public @interface EJB {
+public @interface enterprise bean {
 
     /**
-     * The logical name of the ejb reference within the declaring component's
+     * The logical name of the enterprise bean reference within the declaring component's
      * (e.g., java:comp/env) environment.
      */
     String name() default "";
@@ -68,7 +68,7 @@ public @interface EJB {
      * separated from the path name by &#35;. The path name is relative to the jar file 
      * containing the component that is referencing the target bean.
      * <p>
-     * Only applicable if the target EJB is defined within the 
+     * Only applicable if the target enterprise bean is defined within the 
      * same application or stand-alone module as the declaring component.
      */
     String beanName() default "";
@@ -77,7 +77,7 @@ public @interface EJB {
      * The interface type of the Enterprise Java Bean to which this reference
      * is mapped.
      * <p>
-     * Holds one of the following types of the target EJB :
+     * Holds one of the following types of the target enterprise bean :
      * <ul>
      * <li> Local business interface
      * <li> Bean class (for no-interface view)
@@ -89,8 +89,8 @@ public @interface EJB {
     Class beanInterface() default Object.class;
 
     /**
-     * The product specific name of the EJB component to which this
-     * ejb reference should be mapped.  This mapped name is often a
+     * The product specific name of the enterprise bean component to which this
+     * enterprise bean reference should be mapped.  This mapped name is often a
      * global JNDI name, but may be a name of any form. 
      * <p>
      * Application servers are not required to support any particular 
@@ -101,7 +101,7 @@ public @interface EJB {
     String mappedName() default "";
 
     /**
-     * A portable lookup string containing the JNDI name for the target EJB component. 
+     * A portable lookup string containing the JNDI name for the target enterprise bean component. 
      *
      * @since EJB 3.1
      */ 

--- a/api/src/main/java/javax/ejb/EJBContext.java
+++ b/api/src/main/java/javax/ejb/EJBContext.java
@@ -76,7 +76,7 @@ public interface EJBContext
     /**
      * Obtain the <code>java.security.Identity</code> of the caller.
      *
-     * This method is deprecated in EJB 1.1. The Container
+     * This method is deprecated in enterprise bean 1.1. The Container
      * is allowed to return always <code>null</code> from this method. The enterprise
      * bean should use the <code>getCallerPrincipal</code> method instead.
      *
@@ -103,7 +103,7 @@ public interface EJBContext
     /**
      * Test if the caller has a given role.
      *
-     * <p>This method is deprecated in EJB 1.1. The enterprise bean
+     * <p>This method is deprecated in enterprise bean 1.1. The enterprise bean
      * should use the <code>isCallerInRole(String roleName)</code> method instead.
      *
      * @param role The <code>java.security.Identity</code> of the role to be tested.
@@ -179,7 +179,7 @@ public interface EJBContext
     boolean getRollbackOnly() throws IllegalStateException;
 
     /**
-     * Get access to the EJB Timer Service.
+     * Get access to the enterprise bean Timer Service.
      *
      * @exception IllegalStateException The Container throws the exception
      *    if the instance is not allowed to use this method (e.g. if the bean

--- a/api/src/main/java/javax/ejb/EJBHome.java
+++ b/api/src/main/java/javax/ejb/EJBHome.java
@@ -22,12 +22,12 @@ import java.rmi.RemoteException;
  * The EJBHome interface must be extended by all enterprise beans'
  * remote home interfaces. An enterprise bean's remote home interface
  * defines the methods that allow a remote client to create, find, and
- * remove EJB objects.
+ * remove enterprise bean objects.
  *
  * <p> The remote home interface is defined by the enterprise bean provider and 
  * implemented by the enterprise bean container.
  * <p>
- * Enterprise beans written to the EJB 3.0 and later APIs do not require
+ * Enterprise beans written to the enterprise bean 3.0 and later APIs do not require
  * a home interface.
  *
  * @since EJB 1.0
@@ -35,9 +35,9 @@ import java.rmi.RemoteException;
 public interface EJBHome extends java.rmi.Remote {
 
     /**
-     * Remove an EJB object identified by its handle.
+     * Remove an enterprise bean object identified by its handle.
      *
-     * @param handle the handle of the EJB object to be removed
+     * @param handle the handle of the enterprise bean object to be removed
      *
      * @exception RemoveException Thrown if the enterprise bean or
      *    the container does not allow the client to remove the object.
@@ -48,14 +48,14 @@ public interface EJBHome extends java.rmi.Remote {
     void remove(Handle handle) throws RemoteException, RemoveException;
 
     /**
-     * Remove an EJB object identified by its primary key.
+     * Remove an enterprise bean object identified by its primary key.
      *
      * <p>This method can be used only for an entity bean. An attempt
      * to call this method on a session bean will result in a RemoveException.
      *
-     * <p><b>Note:</b> Support for entity beans is optional as of EJB 3.2.
+     * <p><b>Note:</b> Support for entity beans is optional as of enterprise bean 3.2.
      *
-     * @param primaryKey the primary key of the EJB object to be removed
+     * @param primaryKey the primary key of the enterprise bean object to be removed
      *
      * @exception RemoveException Thrown if the enterprise bean or
      *    the container does not allow the client to remove the object.

--- a/api/src/main/java/javax/ejb/EJBLocalHome.java
+++ b/api/src/main/java/javax/ejb/EJBLocalHome.java
@@ -20,12 +20,12 @@ package javax.ejb;
  * The EJBLocalHome interface must be extended by all enterprise
  * beans' local home interfaces. An enterprise bean's local home
  * interface defines the methods that allow local clients to create, 
- * find, and remove EJB objects.
+ * find, and remove enterprise bean objects.
  *
  * <p> The local home interface is defined by the enterprise bean provider
  * and implemented by the enterprise bean container.
  * <p>
- * Enterprise beans written to the EJB 3.0 and later APIs do not require
+ * Enterprise beans written to the enterprise bean 3.0 and later APIs do not require
  * a local home interface.
  *
  * @since EJB 2.0
@@ -33,15 +33,15 @@ package javax.ejb;
 public interface EJBLocalHome {
 
     /**
-     * Remove an EJB object identified by its primary key.
+     * Remove an enterprise bean object identified by its primary key.
      *
      * <p>This method can only be used by local clients of an entity
      * bean.  An attempt to call this method on a session bean will
      * result in a RemoveException.
      *
-     * <p><b>Note:</b> Support for entity beans is optional as of EJB 3.2.
+     * <p><b>Note:</b> Support for entity beans is optional as of enterprise bean 3.2.
      *
-     * @param primaryKey the primary key of the EJB object to be removed
+     * @param primaryKey the primary key of the enterprise bean object to be removed
      *
      * @exception RemoveException Thrown if the enterprise bean or
      *    the container does not allow the client to remove the object.

--- a/api/src/main/java/javax/ejb/EJBLocalObject.java
+++ b/api/src/main/java/javax/ejb/EJBLocalObject.java
@@ -19,14 +19,14 @@ package javax.ejb;
 /**
  * The EJBLocalObject interface must be extended by all enterprise beans' local
  * interfaces. An enterprise bean's local interface provides the local client 
- * view of an EJB object. An enterprise bean's local interface defines 
+ * view of an enterprise bean object. An enterprise bean's local interface defines 
  * the business methods callable by local clients.
  *
  * <p> The enterprise bean's local interface is defined by the enterprise
  * bean provider and implemented by the enterprise bean container.
  * 
  * <p>
- * Enterprise beans written to the EJB 3.0 and later APIs do not require
+ * Enterprise beans written to the enterprise bean 3.0 and later APIs do not require
  * a local interface that extends the EJBLocalObject interface.  A local
  * business interface can be used instead.
  *
@@ -47,15 +47,15 @@ public interface EJBLocalObject {
     public EJBLocalHome getEJBLocalHome() throws EJBException; 
 
     /**
-     * Obtain the primary key of the EJB local object. 
+     * Obtain the primary key of the enterprise bean local object. 
      *
      * <p> This method can be called on an entity bean. 
      * An attempt to invoke this method on a session bean will result in
      * an EJBException.
      *
-     * <p><b>Note:</b> Support for entity beans is optional as of EJB 3.2.
+     * <p><b>Note:</b> Support for entity beans is optional as of enterprise bean 3.2.
      *
-     * @return The EJB local object's primary key.
+     * @return The enterprise bean local object's primary key.
      *
      * @exception EJBException Thrown when the method failed due to a
      *    system-level failure or when invoked on a session bean.
@@ -64,7 +64,7 @@ public interface EJBLocalObject {
     public Object getPrimaryKey() throws EJBException;
 
     /**
-     * Remove the EJB local object.
+     * Remove the enterprise bean local object.
      *
      * @exception RemoveException The enterprise bean or the container
      *    does not allow destruction of the object.
@@ -76,12 +76,12 @@ public interface EJBLocalObject {
     public void remove() throws RemoveException, EJBException;
 
     /**
-     * Test if a given EJB local object is identical to the invoked EJB 
+     * Test if a given enterprise bean local object is identical to the invoked enterprise bean 
      * local object.
      *
      * @param obj An object to test for identity with the invoked object.
      *
-     * @return True if the given EJB local object is identical to the 
+     * @return True if the given enterprise bean local object is identical to the 
      * invoked object, false otherwise.
      *
      *

--- a/api/src/main/java/javax/ejb/EJBObject.java
+++ b/api/src/main/java/javax/ejb/EJBObject.java
@@ -21,7 +21,7 @@ import java.rmi.RemoteException;
 /**
  * The EJBObject interface is extended by all enterprise beans' remote
  * interfaces. An enterprise bean's remote interface provides the
- * remote client view of an EJB object. An enterprise bean's remote
+ * remote client view of an enterprise bean object. An enterprise bean's remote
  * interface defines the business methods callable by a remote client.
  *
  * <p> The remote interface must extend the javax.ejb.EJBObject
@@ -32,7 +32,7 @@ import java.rmi.RemoteException;
  * bean provider and implemented by the enterprise bean container.
  *
  * <p>
- * Enterprise beans written to the EJB 3.0 and later APIs do not require
+ * Enterprise beans written to the enterprise bean 3.0 and later APIs do not require
  * a remote interface that extends the EJBObject interface.  A remote
  * business interface can be used instead.
  *
@@ -52,14 +52,14 @@ public interface EJBObject extends java.rmi.Remote {
     public EJBHome getEJBHome() throws RemoteException; 
 
     /**
-     * Obtain the primary key of the EJB object. 
+     * Obtain the primary key of the enterprise bean object. 
      *
      * <p> This method can be called on an entity bean. An attempt to invoke
      * this method on a session bean will result in RemoteException.
      *
-     * <p><b>Note:</b> Support for entity beans is optional as of EJB 3.2.
+     * <p><b>Note:</b> Support for entity beans is optional as of enterprise bean 3.2.
      *
-     * @return The EJB object's primary key.
+     * @return The enterprise bean object's primary key.
      *
      * @exception RemoteException Thrown when the method failed due to a
      *    system-level failure or when invoked on a session bean.
@@ -67,7 +67,7 @@ public interface EJBObject extends java.rmi.Remote {
     public Object getPrimaryKey() throws RemoteException;
 
     /**
-     * Remove the EJB object.
+     * Remove the enterprise bean object.
      *
      * @exception RemoteException Thrown when the method failed due to a
      *    system-level failure.
@@ -78,11 +78,11 @@ public interface EJBObject extends java.rmi.Remote {
     public void remove() throws RemoteException, RemoveException;
 
     /**
-     * Obtain a handle for the EJB object. The handle can be used at later
-     * time to re-obtain a reference to the EJB object, possibly in a
+     * Obtain a handle for the enterprise bean object. The handle can be used at later
+     * time to re-obtain a reference to the enterprise bean object, possibly in a
      * different Java Virtual Machine.
      *
-     * @return A handle for the EJB object.
+     * @return A handle for the enterprise bean object.
      *
      * @exception RemoteException Thrown when the method failed due to a
      *    system-level failure.
@@ -90,11 +90,11 @@ public interface EJBObject extends java.rmi.Remote {
     public Handle getHandle() throws RemoteException;
 
     /**
-     * Test if a given EJB object is identical to the invoked EJB object.
+     * Test if a given enterprise bean object is identical to the invoked enterprise bean object.
      *
      * @param obj An object to test for identity with the invoked object.
      *
-     * @return True if the given EJB object is identical to the invoked object,
+     * @return True if the given enterprise bean object is identical to the invoked object,
      *    false otherwise.
      *
      * @exception RemoteException Thrown when the method failed due to a

--- a/api/src/main/java/javax/ejb/EntityBean.java
+++ b/api/src/main/java/javax/ejb/EntityBean.java
@@ -25,11 +25,11 @@ import java.rmi.RemoteException;
  * bean instances of the instance's life cycle events.
  *
  * <p>
- * Applications written to the EJB 3.0 and later APIs should use the facilities
+ * Applications written to the enterprise bean 3.0 and later APIs should use the facilities
  * of the Java Persistence API (<code>javax.persistence</code>) to model
  * persistent entities.
  *
- * <p><b>Note:</b> Support for entity beans is optional as of EJB 3.2.
+ * <p><b>Note:</b> Support for entity beans is optional as of enterprise bean 3.2.
  *
  * @since EJB 1.0
  */
@@ -48,8 +48,8 @@ public interface EntityBean extends EnterpriseBean {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 specification should throw the
      *    javax.ejb.EJBException instead of this exception.
      *    Enterprise beans written for the EJB2.0 and higher specifications
      *    must throw the javax.ejb.EJBException instead of this exception.
@@ -72,8 +72,8 @@ public interface EntityBean extends EnterpriseBean {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 specification should throw the
      *    javax.ejb.EJBException instead of this exception.
      *    Enterprise beans written for the EJB2.0 and higher specifications
      *    must throw the javax.ejb.EJBException instead of this exception.
@@ -81,10 +81,10 @@ public interface EntityBean extends EnterpriseBean {
     public void unsetEntityContext() throws EJBException, RemoteException;
 
     /**
-     * A container invokes this method before it removes the EJB object
+     * A container invokes this method before it removes the enterprise bean object
      * that is currently associated with the instance. This method
      * is invoked when a client invokes a remove operation on the
-     * entity bean's home interface or the EJB object's remote interface.
+     * entity bean's home interface or the enterprise bean object's remote interface.
      * This method transitions the instance from the ready state to the pool 
      * of available instances.
      * 
@@ -99,8 +99,8 @@ public interface EntityBean extends EnterpriseBean {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 specification should throw the
      *    javax.ejb.EJBException instead of this exception.
      *    Enterprise beans written for the EJB2.0 and higher specifications
      *    must throw the javax.ejb.EJBException instead of this exception.
@@ -111,7 +111,7 @@ public interface EntityBean extends EnterpriseBean {
     /**
      * A container invokes this method when the instance
      * is taken out of the pool of available instances to become associated
-     * with a specific EJB object. This method transitions the instance to 
+     * with a specific enterprise bean object. This method transitions the instance to 
      * the ready state.
      *
      * <p> This method executes in an unspecified transaction context.
@@ -121,8 +121,8 @@ public interface EntityBean extends EnterpriseBean {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 specification should throw the
      *    javax.ejb.EJBException instead of this exception.
      *    Enterprise beans written for the EJB2.0 and higher specifications
      *    must throw the javax.ejb.EJBException instead of this exception.
@@ -131,7 +131,7 @@ public interface EntityBean extends EnterpriseBean {
 
     /**
      * A container invokes this method on an instance before the instance
-     * becomes disassociated with a specific EJB object. After this method
+     * becomes disassociated with a specific enterprise bean object. After this method
      * completes, the container will place the instance into the pool of
      * available instances.
      *
@@ -142,8 +142,8 @@ public interface EntityBean extends EnterpriseBean {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 specification should throw the
      *    javax.ejb.EJBException instead of this exception.
      *    Enterprise beans written for the EJB2.0 and higher specifications
      *    must throw the javax.ejb.EJBException instead of this exception.
@@ -163,8 +163,8 @@ public interface EntityBean extends EnterpriseBean {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 specification should throw the
      *    javax.ejb.EJBException instead of this exception.
      *    Enterprise beans written for the EJB2.0 and higher specifications
      *    must throw the javax.ejb.EJBException instead of this exception.
@@ -184,8 +184,8 @@ public interface EntityBean extends EnterpriseBean {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 specification should throw the
      *    javax.ejb.EJBException instead of this exception.
      *    Enterprise beans written for the EJB2.0 and higher specifications
      *    must throw the javax.ejb.EJBException instead of this exception.

--- a/api/src/main/java/javax/ejb/EntityContext.java
+++ b/api/src/main/java/javax/ejb/EntityContext.java
@@ -29,27 +29,27 @@ import java.security.Identity;
  * the lifetime of the instance. Note that the information that the instance
  * obtains using the EntityContext interface (such as the result of the
  * getPrimaryKey() method) may change, as the container assigns the instance
- * to different EJB objects during the instance's life cycle.
+ * to different enterprise bean objects during the instance's life cycle.
  *
- * <p><b>Note:</b> Support for entity beans is optional as of EJB 3.2.
+ * <p><b>Note:</b> Support for entity beans is optional as of enterprise bean 3.2.
  *
  * @since EJB 2.0
  */
 public interface EntityContext extends EJBContext
 {
     /**
-     * Obtain a reference to the EJB local object that is currently 
+     * Obtain a reference to the enterprise bean local object that is currently 
      * associated with the instance.
      *
      * <p> An instance of an entity bean can call this method only
-     * when the instance is associated with an EJB local object identity, i.e.
+     * when the instance is associated with an enterprise bean local object identity, i.e.
      * in the ejbActivate, ejbPassivate, ejbPostCreate, ejbRemove,
      * ejbLoad, ejbStore, and business methods.
      *
      * <p> An instance can use this method, for example, when it wants to
      * pass a reference to itself in a method argument or result.
      *
-     * @return The EJB local object currently associated with the instance.
+     * @return The enterprise bean local object currently associated with the instance.
      *
      * @exception IllegalStateException if the instance invokes this
      *    method while the instance is in a state that does not allow the
@@ -61,18 +61,18 @@ public interface EntityContext extends EJBContext
     EJBLocalObject getEJBLocalObject() throws IllegalStateException;
 
     /**
-     * Obtain a reference to the EJB object that is currently associated with 
+     * Obtain a reference to the enterprise bean object that is currently associated with 
      * the instance.
      *
      * <p> An instance of an entity bean can call this method only
-     * when the instance is associated with an EJB object identity, i.e.
+     * when the instance is associated with an enterprise bean object identity, i.e.
      * in the ejbActivate, ejbPassivate, ejbPostCreate, ejbRemove,
      * ejbLoad, ejbStore, and business methods.
      *
      * <p> An instance can use this method, for example, when it wants to
      * pass a reference to itself in a method argument or result.
      *
-     * @return The EJB object currently associated with the instance.
+     * @return The enterprise bean object currently associated with the instance.
      *
      * @exception IllegalStateException Thrown if the instance invokes this
      *    method while the instance is in a state that does not allow the
@@ -82,11 +82,11 @@ public interface EntityContext extends EJBContext
     EJBObject getEJBObject() throws IllegalStateException;
 
     /**
-     * Obtain the primary key of the EJB object that is currently
+     * Obtain the primary key of the enterprise bean object that is currently
      * associated with this instance.
      *
      * <p> An instance of an entity bean can call this method only
-     * when the instance is associated with an EJB object identity, i.e.
+     * when the instance is associated with an enterprise bean object identity, i.e.
      * in the ejbActivate, ejbPassivate, ejbPostCreate, ejbRemove,
      * ejbLoad, ejbStore, and business methods.
      *

--- a/api/src/main/java/javax/ejb/FinderException.java
+++ b/api/src/main/java/javax/ejb/FinderException.java
@@ -21,9 +21,9 @@ package javax.ejb;
  * of every finder method of an entity bean's home or local home interface.
  *
  * <p> The exception is used as a standard application-level exception to 
- * report a failure to find the requested EJB object(s).
+ * report a failure to find the requested enterprise bean object(s).
  *
- * <p><b>Note:</b> Support for entity beans is optional as of EJB 3.2.
+ * <p><b>Note:</b> Support for entity beans is optional as of enterprise bean 3.2.
  *
  * @since EJB 1.0
  */

--- a/api/src/main/java/javax/ejb/Handle.java
+++ b/api/src/main/java/javax/ejb/Handle.java
@@ -19,19 +19,19 @@ package javax.ejb;
 import java.rmi.RemoteException;
 
 /**
- * The Handle interface is implemented by all EJB object handles. A handle
- * is an abstraction of a network reference to an EJB object. A handle is
- * intended to be used as a "robust" persistent reference to an EJB object.
+ * The Handle interface is implemented by all enterprise bean object handles. A handle
+ * is an abstraction of a network reference to an enterprise bean object. A handle is
+ * intended to be used as a "robust" persistent reference to an enterprise bean object.
  *
  * @since EJB 1.0
  */
 public interface Handle extends java.io.Serializable {
     /**
-     * Obtain the EJB object reference represented by this handle.
+     * Obtain the enterprise bean object reference represented by this handle.
      *
-     * @return the EJB object reference represented by this handle.
+     * @return the enterprise bean object reference represented by this handle.
      *
-     * @exception RemoteException The EJB object could not be obtained
+     * @exception RemoteException The enterprise bean object could not be obtained
      *    because of a system-level failure.
      */
     public EJBObject getEJBObject() throws RemoteException;

--- a/api/src/main/java/javax/ejb/Init.java
+++ b/api/src/main/java/javax/ejb/Init.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Retention;
 /**
  * Designates a method of a session bean that corresponds to a
  * <code>create&#060;METHOD&#062;</code> method of an adapted home or
- * local home interface (an interface that adapts an EJB 2.1 or earlier
+ * local home interface (an interface that adapts an enterprise bean 2.1 or earlier
  * EJBHome or EJBLocalHome client view respectively).
  *
  * <p> The result type of such an <code>Init</code> method is required

--- a/api/src/main/java/javax/ejb/LocalHome.java
+++ b/api/src/main/java/javax/ejb/LocalHome.java
@@ -26,9 +26,9 @@ import java.lang.annotation.Retention;
  * Declares the local home or adapted local home interface
  * for a session bean.
  * <p>
- * Clients written to the EJB 2.1 and earlier client view depend upon the 
+ * Clients written to the enterprise bean 2.1 and earlier client view depend upon the 
  * existence of a home and component interface.
- * A session bean written to the EJB 3.x API may be adapted to such earlier 
+ * A session bean written to the enterprise bean 3.x API may be adapted to such earlier 
  * preexisting client view interfaces.
  * <p>
  * The session bean designates the local home interface to be adapted by using 
@@ -38,7 +38,7 @@ import java.lang.annotation.Retention;
  * create method signature.
  *
  * <p>
- * Session beans written to the EJB 3.0 and later APIs do not otherwise make
+ * Session beans written to the enterprise bean 3.0 and later APIs do not otherwise make
  * use of local home interfaces.
  *
  * @see Init

--- a/api/src/main/java/javax/ejb/MessageDrivenBean.java
+++ b/api/src/main/java/javax/ejb/MessageDrivenBean.java
@@ -17,11 +17,11 @@
 package javax.ejb;
 
 /**
- * The MessageDrivenBean interface defines methods that the EJB container uses
+ * The MessageDrivenBean interface defines methods that the enterprise bean container uses
  * to notify a message driven bean instance of the instance's life cycle 
  * events.
  * <p>
- * As of EJB 3.0 it is no longer required that a message driven bean class
+ * As of enterprise bean 3.0 it is no longer required that a message driven bean class
  * implement this interface.
  *
  * @since EJB 2.0

--- a/api/src/main/java/javax/ejb/NoSuchEntityException.java
+++ b/api/src/main/java/javax/ejb/NoSuchEntityException.java
@@ -26,7 +26,7 @@ package javax.ejb;
  * the business methods defined in the bean's component interface and by 
  * the <code>ejbLoad</code> and <code>ejbStore</code> methods.
  *
- * <p><b>Note:</b> Support for entity beans is optional as of EJB 3.2.
+ * <p><b>Note:</b> Support for entity beans is optional as of enterprise bean 3.2.
  *
  * @since EJB 1.1
  */

--- a/api/src/main/java/javax/ejb/NoSuchObjectLocalException.java
+++ b/api/src/main/java/javax/ejb/NoSuchObjectLocalException.java
@@ -18,7 +18,7 @@ package javax.ejb;
 
 /**  
  * A NoSuchObjectLocalException is thrown if an attempt is made to invoke
- * a method on a local object (local EJB object or timer) that no longer exists.
+ * a method on a local object (local enterprise bean object or timer) that no longer exists.
  *
  * @since EJB 2.0
  */

--- a/api/src/main/java/javax/ejb/ObjectNotFoundException.java
+++ b/api/src/main/java/javax/ejb/ObjectNotFoundException.java
@@ -18,7 +18,7 @@ package javax.ejb;
 
 /**
  * The ObjectNotFoundException exception is thrown by a finder or select method to
- * indicate that the specified EJB object or local object does not exist.
+ * indicate that the specified enterprise bean object or local object does not exist.
  *
  * <p> Only the finder and select methods that are declared to return
  * a single object use this exception. This exception should not be

--- a/api/src/main/java/javax/ejb/RemoteHome.java
+++ b/api/src/main/java/javax/ejb/RemoteHome.java
@@ -26,9 +26,9 @@ import java.lang.annotation.Retention;
  * Declares the remote home interface or adapted remote home interface
  * for a session bean.  The value is never a 2.x remote component interface.
  * <p>
- * Clients written to the EJB 2.1 and earlier client view depend upon the 
+ * Clients written to the enterprise bean 2.1 and earlier client view depend upon the 
  * existence of a home and component interface.
- * A session bean written to the EJB 3.x API may be adapted to such earlier 
+ * A session bean written to the enterprise bean 3.x API may be adapted to such earlier 
  * preexisting client view interfaces.
  * <p>
  * The session bean designates the home interface to be adapted by using 
@@ -37,7 +37,7 @@ import java.lang.annotation.Retention;
  * derived from the return type of remote home interface's
  * create method signature.
  * <p>
- * Session beans written to the EJB 3.0 and later APIs do not otherwise make
+ * Session beans written to the enterprise bean 3.0 and later APIs do not otherwise make
  * use of remote home interfaces.
  *
  * @see Init

--- a/api/src/main/java/javax/ejb/RemoveException.java
+++ b/api/src/main/java/javax/ejb/RemoveException.java
@@ -18,8 +18,8 @@ package javax.ejb;
 
 /**
  * The RemoveException is thrown at an attempt to remove an
- * EJB object or local EJB object when the enterprise bean or the
- * container does not allow the EJB object to be removed.
+ * enterprise bean object or local enterprise bean object when the enterprise bean or the
+ * container does not allow the enterprise bean object to be removed.
  *
  * @since EJB 1.0
  */

--- a/api/src/main/java/javax/ejb/SessionBean.java
+++ b/api/src/main/java/javax/ejb/SessionBean.java
@@ -19,10 +19,10 @@ package javax.ejb;
 import java.rmi.RemoteException;
 
 /**
- * The SessionBean interface defines methods that the EJB container uses
+ * The SessionBean interface defines methods that the enterprise bean container uses
  * to notify a session bean instance of the instance's life cycle events.
  * <p>
- * As of EJB 3.0 it is no longer required that a session bean class
+ * As of enterprise bean 3.0 it is no longer required that a session bean class
  * implement this interface.
  *
  * @since EJB 1.0
@@ -44,8 +44,8 @@ public interface SessionBean extends EnterpriseBean {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for applications written
-     *    for the EJB 1.0 specification. Enterprise beans written for the 
-     *    EJB 1.1 specification should throw the
+     *    for the enterprise bean 1.0 specification. Enterprise beans written for the 
+     *    enterprise bean 1.1 specification should throw the
      *    javax.ejb.EJBException instead of this exception.
      *    Enterprise beans written for the EJB2.0 and higher specifications
      *    must throw the javax.ejb.EJBException instead of this exception.
@@ -66,8 +66,8 @@ public interface SessionBean extends EnterpriseBean {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 specification should throw the
      *    javax.ejb.EJBException instead of this exception.
      *    Enterprise beans written for the EJB2.0 and higher specifications
      *    must throw the javax.ejb.EJBException instead of this exception.
@@ -86,8 +86,8 @@ public interface SessionBean extends EnterpriseBean {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 specification should throw the
      *    javax.ejb.EJBException instead of this exception.
      *    Enterprise beans written for the EJB2.0 and higher specifications
      *    must throw the javax.ejb.EJBException instead of this exception.
@@ -110,8 +110,8 @@ public interface SessionBean extends EnterpriseBean {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 specification should throw the
      *    javax.ejb.EJBException instead of this exception.
      *    Enterprise beans written for the EJB2.0 and higher specifications
      *    must throw the javax.ejb.EJBException instead of this exception.

--- a/api/src/main/java/javax/ejb/SessionContext.java
+++ b/api/src/main/java/javax/ejb/SessionContext.java
@@ -32,7 +32,7 @@ import javax.xml.rpc.handler.MessageContext;
 public interface SessionContext extends EJBContext
 {
     /**
-     * Obtain a reference to the EJB local object that is  
+     * Obtain a reference to the enterprise bean local object that is  
      * associated with the instance.
      *
      * <p> An instance of a session bean can call this method at
@@ -44,7 +44,7 @@ public interface SessionContext extends EJBContext
      * <p> An instance can use this method, for example, when it wants to
      * pass a reference to itself in a method argument or result.
      *
-     * @return The EJB local object currently associated with the instance.
+     * @return The enterprise bean local object currently associated with the instance.
      *
      * @exception IllegalStateException Thrown if the instance invokes this
      *    method while the instance is in a state that does not allow the
@@ -56,7 +56,7 @@ public interface SessionContext extends EJBContext
     EJBLocalObject getEJBLocalObject() throws IllegalStateException;
 
     /**
-     * Obtain a reference to the EJB object that is currently associated with 
+     * Obtain a reference to the enterprise bean object that is currently associated with 
      * the instance.
      *
      * <p> An instance of a session enterprise Bean can call this
@@ -68,7 +68,7 @@ public interface SessionContext extends EJBContext
      * <p> An instance can use this method, for example, when it wants to
      * pass a reference to itself in a method argument or result.
      *
-     * @return The EJB object currently associated with the instance.
+     * @return The enterprise bean object currently associated with the instance.
      *
      * @exception IllegalStateException Thrown if the instance invokes this
      *    method while the instance is in a state that does not allow the
@@ -84,7 +84,7 @@ public interface SessionContext extends EJBContext
      * from any business method invoked through its web service
      * endpoint interface.
      *
-     * <p><b>Note:</b> Support for web services invocations using JAX-RPC is optional as of EJB 3.2
+     * <p><b>Note:</b> Support for web services invocations using JAX-RPC is optional as of enterprise bean 3.2
      *
      * @return The MessageContext for this web service invocation.
      *

--- a/api/src/main/java/javax/ejb/SessionSynchronization.java
+++ b/api/src/main/java/javax/ejb/SessionSynchronization.java
@@ -48,10 +48,10 @@ public interface SessionSynchronization {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 and later specifications should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 and later specifications should throw the
      *    javax.ejb.EJBException instead of this exception. 
-     *    Enterprise beans written for the EJB 2.0 and later specifications 
+     *    Enterprise beans written for the enterprise bean 2.0 and later specifications 
      *    must not throw the java.rmi.RemoteException.
      *
      * @see AfterBegin
@@ -74,10 +74,10 @@ public interface SessionSynchronization {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 and later specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 and later specification should throw the
      *    javax.ejb.EJBException instead of this exception.
-     *    Enterprise beans written for the EJB 2.0 and later specifications 
+     *    Enterprise beans written for the enterprise bean 2.0 and later specifications 
      *    must not throw the java.rmi.RemoteException.
      *
      * @see BeforeCompletion
@@ -99,10 +99,10 @@ public interface SessionSynchronization {
      *
      * @exception RemoteException This exception is defined in the method
      *    signature to provide backward compatibility for enterprise beans 
-     *    written for the EJB 1.0 specification. Enterprise beans written 
-     *    for the EJB 1.1 and later specification should throw the
+     *    written for the enterprise bean 1.0 specification. Enterprise beans written 
+     *    for the enterprise bean 1.1 and later specification should throw the
      *    javax.ejb.EJBException instead of this exception. 
-     *    Enterprise beans written for the EJB 2.0 and later specifications 
+     *    Enterprise beans written for the enterprise bean 2.0 and later specifications 
      *    must not throw the java.rmi.RemoteException.
      *
      * @see AfterCompletion

--- a/api/src/main/java/javax/ejb/TimedObject.java
+++ b/api/src/main/java/javax/ejb/TimedObject.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
  * The <code>TimedObject</code> interface contains a callback method
  * that is used to deliver timer expiration notifications.  It can be
  * implemented by a stateless session bean class, a singleton session
- * bean class, a message-driven bean class, or an EJB 2.x entity bean class.
+ * bean class, a message-driven bean class, or an enterprise bean 2.x entity bean class.
  * <p>
  * If the bean implements the <code>TimedObject</code> interface, the
  * <code>Timeout</code> annotation, if used, can only be applied to 
@@ -35,7 +35,7 @@ import java.io.Serializable;
 public interface TimedObject {
 
     /**
-     * Invoked by the EJB container upon timer expiration.
+     * Invoked by the enterprise bean container upon timer expiration.
      *
      * @param timer timer whose expiration caused this notification.
      *

--- a/api/src/main/java/javax/ejb/Timeout.java
+++ b/api/src/main/java/javax/ejb/Timeout.java
@@ -23,8 +23,8 @@ import static java.lang.annotation.RetentionPolicy.*;
 
 /**
  * Designates a method on a stateless session bean class, a singleton
- * session bean class, a message driven bean class, or an EJB 2.x entity bean
- * class that should receive EJB timer expirations for that bean.
+ * session bean class, a message driven bean class, or an enterprise bean 2.x entity bean
+ * class that should receive enterprise bean timer expirations for that bean.
  * <p>
  * The method to which the <code>Timeout</code> annotation is applied
  * must have one of the following signatures, where <code>&#060;METHOD&#062;</code>

--- a/api/src/main/java/javax/ejb/Timer.java
+++ b/api/src/main/java/javax/ejb/Timer.java
@@ -22,7 +22,7 @@ import java.util.Date;
 /**
  *
  * The <code>Timer</code> interface contains information about a timer
- * that was created through the EJB Timer Service.
+ * that was created through the enterprise bean Timer Service.
  *
  * @since EJB 2.1
  */

--- a/api/src/main/java/javax/ejb/TimerService.java
+++ b/api/src/main/java/javax/ejb/TimerService.java
@@ -22,9 +22,9 @@ import java.util.Collection;
 
 /**
  * The TimerService interface provides enterprise bean components with
- * access to the container-provided Timer Service.  The EJB Timer
+ * access to the container-provided Timer Service.  The enterprise bean Timer
  * Service allows stateless session beans, singleton session beans,
- * message-driven beans, and EJB 2.x entity beans to be registered for
+ * message-driven beans, and enterprise bean 2.x entity beans to be registered for
  * timer callback events at a specified time, after a specified
  * elapsed time, after a specified interval, or according to a
  * calendar-based schedule.

--- a/api/src/main/java/javax/ejb/embeddable/EJBContainer.java
+++ b/api/src/main/java/javax/ejb/embeddable/EJBContainer.java
@@ -29,7 +29,7 @@ import javax.ejb.EJBException;
 import javax.ejb.spi.EJBContainerProvider;
 
 /** 
-  * Used to execute an EJB application in an embeddable container.  
+  * Used to execute an enterprise bean application in an embeddable container.  
   *
   * @since EJB 3.1
   */
@@ -56,7 +56,7 @@ public abstract class EJBContainer implements AutoCloseable {
 
     /**
      * Standard property name for specifying the application name of
-     * the EJB modules executing within the embeddable container. If
+     * the enterprise bean modules executing within the embeddable container. If
      * specified, the property value applies to the
      * <code>&#060;app-name&#062;</code> portion of the portable
      * global JNDI name syntax. If this property is not specified, the
@@ -66,7 +66,7 @@ public abstract class EJBContainer implements AutoCloseable {
     public static final String APP_NAME = "javax.ejb.embeddable.appName";
 
     /**
-     * Create and initialize an embeddable EJB container.  JVM classpath is 
+     * Create and initialize an embeddable enterprise bean container.  JVM classpath is 
      * searched for all ejb-jars or exploded ejb-jars in directory format.
      *
      * @return EJBContainer instance
@@ -79,7 +79,7 @@ public abstract class EJBContainer implements AutoCloseable {
     }
 
     /**
-     * Create and initialize an embeddable EJB container with a
+     * Create and initialize an embeddable enterprise bean container with a
      * set of configuration properties.
      *
      * @param properties Spec-defined and/or vendor-specific

--- a/api/src/main/java/javax/ejb/embeddable/package.html
+++ b/api/src/main/java/javax/ejb/embeddable/package.html
@@ -22,7 +22,7 @@
 </HEAD>
 <BODY BGCOLOR="white">
 
-Defines the classes for the EJB Embeddable API. 
+Defines the classes for the enterprise bean Embeddable API. 
 
 
 </BODY>

--- a/api/src/main/java/javax/ejb/package.html
+++ b/api/src/main/java/javax/ejb/package.html
@@ -24,7 +24,7 @@
 
 Contains the Enterprise JavaBeans classes 
 and interfaces that define the contracts between the enterprise bean 
-and its clients and between the enterprise bean and the EJB container.
+and its clients and between the enterprise bean and the enterprise bean container.
 
 </BODY>
 </HTML>

--- a/api/src/main/java/javax/ejb/spi/HandleDelegate.java
+++ b/api/src/main/java/javax/ejb/spi/HandleDelegate.java
@@ -25,10 +25,10 @@ import javax.ejb.EJBHome;
 
 
 /**
- * The <code>HandleDelegate</code> interface is implemented by the EJB container. 
+ * The <code>HandleDelegate</code> interface is implemented by the enterprise bean container. 
  * It is used by portable implementations of <code>javax.ejb.Handle</code> and
  * <code>javax.ejb.HomeHandle</code>.
- * It is not used by EJB components or by client components.
+ * It is not used by enterprise bean components or by client components.
  * It provides methods to serialize and deserialize EJBObject and
  * EJBHome references to streams.
  *

--- a/api/src/main/java/javax/ejb/spi/package.html
+++ b/api/src/main/java/javax/ejb/spi/package.html
@@ -23,7 +23,7 @@
 <BODY BGCOLOR="white">
 
 Defines interfaces that are implemented by
-the EJB container. These interfaces are not used by application components.
+the enterprise bean container. These interfaces are not used by application components.
 
 
 </BODY>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <packaging>pom</packaging>
     <version>3.2.3-SNAPSHOT</version>
     <name>${extension.name} API</name>
-    <description>Eclipse Project for EJB</description>
+    <description>Jakarta Enterprise Beans</description>
     <url>https://github.com/eclipse-ee4j/ejb-api</url>
 
     <scm>

--- a/spec/assembly.xml
+++ b/spec/assembly.xml
@@ -22,7 +22,7 @@
     <formats>
     <format>zip</format>
     </formats>
-    <baseDirectory>enterprise-beans-spec</baseDirectory>
+    <baseDirectory>jakarta-enterprise-beans-spec</baseDirectory>
     <fileSets>
         <fileSet>
             <directory>target/generated-docs</directory>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -23,7 +23,7 @@
         <version>3.2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>enterprise-beans-spec</artifactId>
+    <artifactId>jakarta-enterprise-beans-spec</artifactId>
     <packaging>pom</packaging>
     <name>Jakarta Enterprise Beans Specification</name>
 


### PR DESCRIPTION
Removed all references to EJB and replaced with enterprise beans or Jakarta Enterprise Beans, except for package and type names, xml element names, and other code artifacts names.

Signed-off-by: Richard Monson-Haefel <rmonson@tomitribe.com>