### PR TITLE
Build also using OpenJDK9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: java
-jdk: openjdk8
+jdk:
+  - openjdk8
+  - openjdk9
 


### PR DESCRIPTION
As Jenkins is configured to use JDK9, I propose to use JDK9 to build on travis as well (with keeping JDK8).