### PR TITLE
Make @Schedule repeatable

### DIFF
--- a/api/src/main/java/jakarta/ejb/Schedule.java
+++ b/api/src/main/java/jakarta/ejb/Schedule.java
@@ -16,6 +16,7 @@
 
 package jakarta.ejb;
 
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.*;
 import java.lang.annotation.Retention;
@@ -197,6 +198,7 @@ import static java.lang.annotation.RetentionPolicy.*;
  */
 @Target(METHOD) 
 @Retention(RUNTIME)
+@Repeatable(Schedules.class)
 public @interface Schedule {
 
     /**


### PR DESCRIPTION
Adding use of repeatable was discussed as OK during this Tuesday's platform call.  Adding the obvious one.

Ironically, @Schedule was the example used in this documentation :)

 - https://docs.oracle.com/javase/tutorial/java/annotations/repeating.html

Kind of fun to finally make that annotation actually do as the example indicates is possible.