### PR TITLE
Remove javax.transaction in MANIFEST.MF

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -242,7 +242,6 @@
                         <Specification-Vendor>Eclipse Foundation</Specification-Vendor>
                         <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
                         <Implementation-Vendor-Id>org.eclipse.ee4j.ejb</Implementation-Vendor-Id>
-                        <Import-Package>javax.transaction;version="[1.3,2.0)",*</Import-Package>
                     </instructions>
                 </configuration>
                 <executions>


### PR DESCRIPTION
The Import-Package is explicitly adding javax.transaction to MANIFEST.MF
By default this will include jakarta.transaction

Fixes #80 