### PR TITLE
Prepare for next release 4.0.0-RC2

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,6 +23,7 @@
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>1.0.6</version>
+        <relativePath />
     </parent>
 
     <groupId>jakarta.ejb</groupId>
@@ -36,7 +37,7 @@
         <findbugs.version>3.0.5</findbugs.version>
         <findbugs.exclude>exclude.xml</findbugs.exclude>
         <findbugs.threshold>Low</findbugs.threshold>
-        <legal.doc.source>.</legal.doc.source>
+        <legal.doc.source>../</legal.doc.source>
     </properties>
 
     <name>Jakarta Enterprise Beans</name>
@@ -52,14 +53,13 @@
             <organizationUrl>http://www.oracle.com/</organizationUrl>
         </developer>
     </developers>
-
     <contributors>
         <contributor>
             <name>Marina Vatkina</name>
             <organization>Oracle Corporation</organization>
             <organizationUrl>http://www.oracle.com/</organizationUrl>
         </contributor>
-      </contributors>
+    </contributors>
 
     <licenses>
         <license>
@@ -81,11 +81,9 @@
         <connection>scm:git:ssh://git@github.com/eclipse-ee4j/ejb-api.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/eclipse-ee4j/ejb-api.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/ejb-api</url>
-      <tag>HEAD</tag>
-  </scm>
-  
+        <tag>HEAD</tag>
+    </scm>
     <build>
-
         <resources>
             <resource>
                 <directory>src/main/java</directory>
@@ -95,7 +93,6 @@
                 </includes>
             </resource>
         </resources>
-
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -106,11 +103,6 @@
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>spec-version-maven-plugin</artifactId>
                     <version>2.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.glassfish.build</groupId>
-                    <artifactId>glassfishbuild-maven-plugin</artifactId>
-                    <version>3.2.26</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
@@ -124,35 +116,18 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-remote-resources-plugin</artifactId>
-                    <version>1.5</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
                     <version>${findbugs.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.scm</groupId>
-                            <artifactId>maven-scm-provider-gitexe</artifactId>
-                            <version>1.11.1</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -164,32 +139,20 @@
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.0.0-M2</version>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
-                </plugin>
-                <plugin>
-                    <!-- Enables step-by-step staging deployment -->
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.7</version>
-                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-            		<configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-               </configuration>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
-                <version>2.1</version>
                 <configuration>
                     <spec>
                         <specVersion>4.0</specVersion>
@@ -249,44 +212,28 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-remote-resources-plugin</artifactId>
-                <executions>
-                  <execution>
-                    <goals>
-                      <goal>process</goal>
-                    </goals>
-                    <configuration>
-                      <resourceBundles>
-                        <resourceBundle>org.glassfish:legal:1.1</resourceBundle>
-                      </resourceBundles>
-                    </configuration>
-                  </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <configuration>
                     <includePom>true</includePom>
                 </configuration>
                 <executions>
                     <execution>
-                       <id>attach-sources</id>
-                       <goals>
-                           <goal>jar-no-fork</goal>
-                       </goals>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <source>1.8</source>
+                    <doclint>none</doclint>
                     <bottom>
-                    <![CDATA[
-                    <p align="left">Copyright &#169; 2019 Eclipse Foundation.<br>Use is subject to
+                        <![CDATA[
+                    <p align="left">Copyright &#169; 2019-${current.year} Eclipse Foundation.<br>Use is subject to
     <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
                     </bottom>
                     <docfilessubdirs>true</docfilessubdirs>
@@ -330,10 +277,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
-                    <mavenExecutorId>forked-path</mavenExecutorId>
-                    <useReleaseProfile>false</useReleaseProfile>
                     <tagNameFormat>@{project.version}</tagNameFormat>
-                    <arguments>${release.arguments}</arguments>
                     <preparationGoals>install</preparationGoals>
                     <goals>deploy</goals>
                 </configuration>
@@ -370,15 +314,11 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://jakarta.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>add-legal-resource</id>
@@ -397,6 +337,17 @@
                                     <targetPath>META-INF</targetPath>
                                 </resource>
                             </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>timestamp-property</id>
+                        <goals>
+                            <goal>timestamp-property</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <name>current.year</name>
+                            <pattern>yyyy</pattern>
                         </configuration>
                     </execution>
                 </executions>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.ejb</groupId>
     <artifactId>jakarta.ejb-api</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-RC2</version>
 
     <properties>
         <extension.name>jakarta.ejb</extension.name>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.ejb</groupId>
     <artifactId>jakarta.ejb-api</artifactId>
-    <version>4.0.0-RC1</version>
+    <version>4.0.0-SNAPSHOT</version>
 
     <properties>
         <extension.name>jakarta.ejb</extension.name>
@@ -372,7 +372,7 @@
                 </executions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://jakarta.oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>false</autoReleaseAfterClose>
                 </configuration>
             </plugin>

--- a/api/src/main/java/jakarta/ejb/ScheduleExpression.java
+++ b/api/src/main/java/jakarta/ejb/ScheduleExpression.java
@@ -32,7 +32,7 @@ import java.io.Serializable;
  * attribute in the common case that the value is a simple integer value. </p>
  * 
  * <p>For example, <pre>scheduleExpression.second(10)</pre> is semantically equivalent to 
- *      <pre>scheduleExpression.second("10")</pre></p>
+ *      <pre>scheduleExpression.second("10")</pre>
  *
  *
  *
@@ -195,7 +195,7 @@ import java.io.Serializable;
  * <li>  year: "*"
  * <li>  timezone : default JVM time zone
  * <li>  start : upon timer creation
- * <li>  end : no end date</p>
+ * <li>  end : no end date
  * </ul>
  *
  * <p>

--- a/api/src/main/java/jakarta/ejb/StatefulTimeout.java
+++ b/api/src/main/java/jakarta/ejb/StatefulTimeout.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
  * is eligible for removal by the container.
  * <p>
  * 
- * The semantics of the <code>value</value> element are as follows:
+ * The semantics of the <code>value</code> element are as follows:
  * <ul>
  * <li>A value <code>&#062;</code>0 indicates a timeout value in the units
  * specified by the <code>unit</code> element.

--- a/api/src/main/java/jakarta/ejb/Timer.java
+++ b/api/src/main/java/jakarta/ejb/Timer.java
@@ -56,7 +56,7 @@ public interface Timer {
      * @throws jakarta.ejb.NoSuchObjectLocalException If invoked on a timer
  that has expired or has been cancelled.
      *
-     * @exception jakarta.ejb.NoMoreTimeoutsExceptions Indicates that the 
+     * @exception jakarta.ejb.NoMoreTimeoutsException Indicates that the 
      * timer has no future timeouts
      * @throws jakarta.ejb.EJBException If this method could not complete due
  to a system-level failure.
@@ -76,7 +76,7 @@ public interface Timer {
      * @throws jakarta.ejb.NoSuchObjectLocalException If invoked on a timer
  that has expired or has been cancelled.
      * 
-     * @exception jakarta.ejb.NoMoreTimeoutsExceptions Indicates that the 
+     * @exception jakarta.ejb.NoMoreTimeoutsException Indicates that the 
      * timer has no future timeouts
      * @throws jakarta.ejb.EJBException If this method could not complete due
  to a system-level failure.

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <groupId>org.eclipse.ee4j.ejb-api</groupId>
     <artifactId>ejb-api-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.0-RC1</version>
+    <version>4.0.0-SNAPSHOT</version>
     <name>${extension.name} API</name>
     <description>Jakarta Enterprise Beans</description>
     <url>https://github.com/eclipse-ee4j/ejb-api</url>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -178,23 +178,6 @@
                 </configuration>
 
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.2</version>
-                <configuration>
-                    <mavenExecutorId>forked-path</mavenExecutorId>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <arguments>${release.arguments}</arguments>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.9.4</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
 
             <!--
                 This is the rule that builds the zip file for download.

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -101,9 +101,6 @@
                             <attributes>
                                 <toc>left</toc>
                             </attributes>
-                            <attributes>
-                                <toc>left</toc>
-                            </attributes>
                         </configuration>
                     </execution>
                     <execution>
@@ -137,9 +134,6 @@
                             <backend>html5</backend>
                             <sourceDocumentName>enterprise-beans-spec-opt.adoc</sourceDocumentName>
                             <outputFile>${project.build.directory}/generated-docs/enterprise-beans-spec-opt-${project.version}.html</outputFile>
-                            <attributes>
-                                <toc>left</toc>
-                            </attributes>
                             <attributes>
                                 <toc>left</toc>
                             </attributes>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.ejb-api</groupId>
         <artifactId>ejb-api-parent</artifactId>
-        <version>4.0.0-RC1</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>enterprise-beans-spec</artifactId>


### PR DESCRIPTION
- [x] [api] Merge 4.0.0-RC1 branch in master
- [x] [api] Add an empty relativePath to parent to resolve ee4j-parent from repository instead of parent directory
- [x] [api] Legal documents in release jar are incorrect
 - The CDDL license.txt is included in META-INF. This is pulled from org.glassfish:legal:1.1 by maven-remote-resources-plugin. This needs to be removed.
 - The legal.doc.source property is pointing to current directory, this should be changed to parent directory. The License.md and Notice.md reside in the parent directory.
- [x] [api] Remove the maven-release-plugin, maven-gpg-plugin and nexus-staging-maven-plugin as they are already configured in the parent
- [x] [api] Upgrade java compiler source and target version from 1.6 to 1.8
- [x] [api] Unable to build with JDK11 - Fix javadoc issues and configure maven-javadoc-plugin with source as 1.8
- [x] [api] Prepare for 4.0.0-RC2
- [x] [spec] asciidoc-to-html does not stamp project version, date and status in HTML output.
- [x] [spec] Remove the maven-release-plugin as it is unused.

Fixes #82