### PR TITLE
[spec] Fix italics rendered in HTML but not in PDF output

### DIFF
--- a/spec/src/main/asciidoc/core/SecurityManagement.adoc
+++ b/spec/src/main/asciidoc/core/SecurityManagement.adoc
@@ -830,11 +830,11 @@ service endpoint. There are three legal styles for composing the method
 element:
 
 *Style 1:*
-[source, xml, subs=+quotes]
+[source, xml]
 ----
 <method>
-    <ejb-name>__EJBNAME__</ejb-name>
-    <method-name>__*__</method-name>
+    <ejb-name>EJBNAME</ejb-name>
+    <method-name>*</method-name>
 </method>
 ----
 This style is used for referring to all of the methods of the business,
@@ -842,11 +842,11 @@ home, and component interfaces, no-interface view, and web service
 endpoint of a specified enterprise bean.
 
 *Style 2:*
-[source, xml, subs=+quotes]
+[source, xml]
 ----
 <method>
-    <ejb-name>__EJBNAME__</ejb-name>
-    <method-name>__METHOD__</method-name>
+    <ejb-name>EJBNAME</ejb-name>
+    <method-name>METHOD</method-name>
 </method>
 ----
 This style is used for referring to a specified method of the business,
@@ -856,15 +856,15 @@ same overloaded name, this style refers to all of the overloaded
 methods.
 
 *Style 3:*
-[source, xml, subs=+quotes]
+[source, xml]
 ----
 <method>
-    <ejb-name>__EJBNAME__</ejb-name>
-        <method-name>__METHOD__</method-name>
+    <ejb-name>EJBNAME</ejb-name>
+        <method-name>METHOD</method-name>
         <method-params>
-        <method-param>__PARAMETER_1__</method-param>
+        <method-param>PARAMETER_1</method-param>
         ...
-        <method-param>__PARAMETER_N__</method-param>
+        <method-param>PARAMETER_N</method-param>
     </method-params>
 </method>
 ----

--- a/spec/src/main/asciidoc/core/SupportForTransactions.adoc
+++ b/spec/src/main/asciidoc/core/SupportForTransactions.adoc
@@ -1208,11 +1208,11 @@ There are three legal styles of composing the
 `method` element:
 
 *Style 1:*
-[source, xml, subs=+quotes]
+[source, xml]
 ----
 <method>
-    <ejb-name>__EJBNAME__</ejb-name>
-    <method-name>__*__</method-name>
+    <ejb-name>EJBNAME</ejb-name>
+    <method-name>*</method-name>
 </method>
 ----
 
@@ -1242,11 +1242,11 @@ bean lifecycle callback methods to specify their transaction attributes
 if used with the `method-intf` element value `LifecycleCallback`.
 
 *Style 2:*
-[source, xml, subs=+quotes]
+[source, xml]
 ----
 <method>
-    <ejb-name>__EJBNAME__</ejb-name>
-    <method-name>__METHOD__</method-name>
+    <ejb-name>EJBNAME</ejb-name>
+    <method-name>METHOD</method-name>
 </method>
 ----
 
@@ -1279,15 +1279,15 @@ specified enterprise bean are lifecycle callback methods
 contains `LifecycleCallback` as the value
 
 *Style 3:*
-[source, xml, subs=+quotes]
+[source, xml]
 ----
 <method>
-    <ejb-name>__EJBNAME__</ejb-name>
-    <method-name>__METHOD__</method-name>
+    <ejb-name>EJBNAME</ejb-name>
+    <method-name>METHOD</method-name>
     <method-params>
-        <method-param>__PARAMETER_1__</method-param>
+        <method-param>PARAMETER_1</method-param>
         ...
-        <method-param>__PARAMETER_N__</method-param>
+        <method-param>PARAMETER_N</method-param>
     </method-params>
 </method>
 ----


### PR DESCRIPTION
Remove double italics from code block since it is rendered as `<em>` tag in PDF output

**HTML:**
![image](https://user-images.githubusercontent.com/16149023/79141286-232fd780-7dd7-11ea-9128-7f09e368ba73.png)

**PDF:**
![image](https://user-images.githubusercontent.com/16149023/79141380-51adb280-7dd7-11ea-8413-169fcfe6c10c.png)

Signed-off-by: hussainnm <hussain.nm@cognizant.com>