### PR TITLE
Update copyright years, specification name and URL in license text

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -232,9 +232,7 @@
                     <source>1.8</source>
                     <doclint>none</doclint>
                     <bottom>
-                        <![CDATA[
-                    <p align="left">Copyright &#169; 2019-${current.year} Eclipse Foundation.<br>Use is subject to
-    <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
+                        <![CDATA[<p align="left">Copyright &#169; 2018, ${current.year} Eclipse Foundation.<br>Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
                     </bottom>
                     <docfilessubdirs>true</docfilessubdirs>
                     <doctitle>Jakarta Enterprise Beans ${project.version} API</doctitle>

--- a/api/src/main/javadoc/doc-files/EFSL.html
+++ b/api/src/main/javadoc/doc-files/EFSL.html
@@ -20,8 +20,9 @@
   <li>All existing copyright notices, or if one does not exist, a notice
       (hypertext is preferred, but a textual representation is permitted)
       of the form: &quot;Copyright &copy; [$date-of-document]
-      &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
-      &quot;
+      Eclipse Foundation, Inc. 
+	  <a href="https://www.eclipse.org/legal/efsl.php">
+	  https://www.eclipse.org/legal/efsl.php</a>&quot;
   </li>
 </ul>
 
@@ -42,9 +43,11 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
-  document includes material copied from or derived from [title and URI
-  of the Eclipse Foundation specification document].&quot;</p>
+<p>&quot;Copyright &copy; 2018, 2020 Eclipse Foundation. This software or
+  document includes material copied from or derived from Jakarta&reg; 
+  Enterprise Beans 
+  <a href="https://jakarta.ee/specifications/enterprise-beans/4.0/">
+  https://jakarta.ee/specifications/enterprise-beans/4.0/</a>.&quot;</p>
 
 <h2>Disclaimers</h2>
 

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -9,9 +9,10 @@ Status: {revremark}
 Release: {revdate}
 ....
 
-=== Copyright
+== Copyright
 
-Copyright (c) 2019 Eclipse Foundation.
+Copyright (C) 2018, 2020 Eclipse Foundation. 
+https://www.eclipse.org/legal/efsl.php[]
 
 === Eclipse Foundation Specification License
 
@@ -29,8 +30,8 @@ document, or portions thereof, that you use:
 * link or URL to the original Eclipse Foundation document.
 * All existing copyright notices, or if one does not exist, a notice
   (hypertext is preferred, but a textual representation is permitted)
-  of the form: "Copyright (c) [$date-of-document]
-  Eclipse Foundation, Inc. <<url to this license>>"
+  of the form: "Copyright (C) [$date-of-document]
+  Eclipse Foundation, Inc. https://www.eclipse.org/legal/efsl.php[]"
 
 Inclusion of the full text of this NOTICE must be provided. We
 request that authorship attribution be provided in any software,
@@ -49,9 +50,10 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright (c) 2018 Eclipse Foundation. This software or
-document includes material copied from or derived from [title and URI
-of the Eclipse Foundation specification document]."
+"Copyright (C) 2018, 2020 Eclipse Foundation. This software or
+document includes material copied from or derived from 
+Jakarta(R) Enterprise Beans 
+https://jakarta.ee/specifications/enterprise-beans/4.0/[]"
 
 ==== Disclaimers
 


### PR DESCRIPTION
Replace placeholders in license text with appropriate information

- Update copyright years
- Add Specification name and URL