### PR TITLE
Cleanup pom

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -153,7 +153,6 @@
                     <version>${maven-javadoc-plugin.version}</version>
                     <configuration>
                         <source>${maven.compiler.source}</source>
-                        <doclint>none</doclint>
                         <bottom>
                             <![CDATA[<p align="left">Copyright &#169; 2018, ${current.year} Eclipse Foundation.<br>Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
                         </bottom>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -34,9 +34,6 @@
         <extension.name>jakarta.ejb</extension.name>
         <spec.version>${project.version}</spec.version>
         <non.final>false</non.final>
-        <findbugs.version>3.0.5</findbugs.version>
-        <findbugs.exclude>exclude.xml</findbugs.exclude>
-        <findbugs.threshold>Low</findbugs.threshold>
         <legal.doc.source>../</legal.doc.source>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -46,8 +43,12 @@
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <spotbugs-maven-plugin.version>4.0.0</spotbugs-maven-plugin.version>
+        <spotbugs.version>4.0.3</spotbugs.version>
         <maven-site-plugin.version>3.9.0</maven-site-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+        <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
+        <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
         <jakarta.transaction-api.version>2.0.0-RC1</jakarta.transaction-api.version>
     </properties>
 
@@ -134,11 +135,29 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven-javadoc-plugin.version}</version>
+                    <configuration>
+                        <source>${maven.compiler.source}</source>
+                        <doclint>none</doclint>
+                        <bottom>
+                            <![CDATA[<p align="left">Copyright &#169; 2018, ${current.year} Eclipse Foundation.<br>Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
+                        </bottom>
+                        <docfilessubdirs>true</docfilessubdirs>
+                        <doctitle>Jakarta Enterprise Beans ${project.version} API</doctitle>
+                        <windowtitle>Jakarta Enterprise Beans ${project.version} API</windowtitle>
+                    </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>${findbugs.version}</version>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${spotbugs-maven-plugin.version}</version>
+                    <dependencies>
+                        <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+                        <dependency>
+                            <groupId>com.github.spotbugs</groupId>
+                            <artifactId>spotbugs</artifactId>
+                            <version>${spotbugs.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -241,16 +260,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <doclint>none</doclint>
-                    <bottom>
-                        <![CDATA[<p align="left">Copyright &#169; 2018, ${current.year} Eclipse Foundation.<br>Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
-                    </bottom>
-                    <docfilessubdirs>true</docfilessubdirs>
-                    <doctitle>Jakarta Enterprise Beans ${project.version} API</doctitle>
-                    <windowtitle>Jakarta Enterprise Beans ${project.version} API</windowtitle>
-                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -275,41 +284,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <configuration>
-                    <threshold>${findbugs.threshold}</threshold>
-                    <excludeFilterFile>${findbugs.exclude}</excludeFilterFile>
-                    <findbugsXmlOutput>true</findbugsXmlOutput>
-                    <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <tagNameFormat>@{project.version}</tagNameFormat>
                     <preparationGoals>install</preparationGoals>
                     <goals>deploy</goals>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <configuration>
-                    <reporting>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.codehaus.mojo</groupId>
-                                <artifactId>findbugs-maven-plugin</artifactId>
-                                <version>${findbugs.version}</version>
-                                <configuration>
-                                    <threshold>${findbugs.threshold}</threshold>
-                                    <excludeFilterFile>${findbugs.exclude}</excludeFilterFile>
-                                </configuration>
-                            </plugin>
-                        </plugins>
-                    </reporting>
                 </configuration>
             </plugin>
             <plugin>
@@ -329,7 +309,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${build-helper-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>add-legal-resource</id>
@@ -359,6 +339,7 @@
                         <configuration>
                             <name>current.year</name>
                             <pattern>yyyy</pattern>
+                            <locale>en</locale>
                         </configuration>
                     </execution>
                 </executions>
@@ -388,6 +369,30 @@
             </plugin>
         </plugins>
     </build>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>${maven-project-info-reports-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>aggregate-no-fork</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
     <dependencies>
         <dependency>
             <groupId>jakarta.transaction</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -32,9 +32,10 @@
 
     <properties>
         <extension.name>jakarta.ejb</extension.name>
-        <spec.version>${project.version}</spec.version>
-        <non.final>false</non.final>
+        <spec.version>4.0</spec.version>
         <legal.doc.source>../</legal.doc.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -56,7 +57,9 @@
     <description>Jakarta Enterprise Beans</description>
 
     <url>https://github.com/eclipse-ee4j/ejb-api</url>
-
+    <organization>
+        <url>https://projects.eclipse.org/projects/ee4j.ejb</url>
+    </organization>
     <developers>
         <developer>
             <id>yaminikb</id>
@@ -92,9 +95,21 @@
     <scm>
         <connection>scm:git:ssh://git@github.com/eclipse-ee4j/ejb-api.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/eclipse-ee4j/ejb-api.git</developerConnection>
-        <url>https://github.com/eclipse-ee4j/ejb-api</url>
+        <url>https://github.com/eclipse-ee4j/ejb-api/tree/${project.scm.tag}</url>
         <tag>HEAD</tag>
     </scm>
+    <mailingLists>
+        <mailingList>
+            <name>Enterprise Beans developer discussions</name>
+            <post>mailto:ejb-dev@eclipse.org</post>
+            <subscribe>mailto:ejb-dev-request@eclipse.org?subject=subscribe</subscribe>
+            <unsubscribe>mailto:ejb-dev-request@eclipse.org?subject=unsubscribe</unsubscribe>
+            <archive>http://www.eclipse.org/lists/ejb-dev</archive>
+            <otherArchives>
+                <otherArchive>http://www.eclipse.org/lists/ejb-dev/maillist.rss</otherArchive>
+            </otherArchives>
+        </mailingList>
+    </mailingLists>
     <build>
         <resources>
             <resource>
@@ -185,9 +200,10 @@
                 <artifactId>spec-version-maven-plugin</artifactId>
                 <configuration>
                     <spec>
-                        <specVersion>4.0</specVersion>
+                        <jarType>api</jarType>
+                        <specVersion>${spec.version}</specVersion>
                         <specImplVersion>${project.version}</specImplVersion>
-                        <apiPackage>jakarta.ejb</apiPackage>
+                        <apiPackage>${extension.name}</apiPackage>
                     </spec>
                 </configuration>
                 <executions>
@@ -215,9 +231,7 @@
                         <Bundle-Description>
                             Jakarta Enterprise Beans ${spec.version} API Design Specification
                         </Bundle-Description>
-                        <Specification-Vendor>Eclipse Foundation</Specification-Vendor>
-                        <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
-                        <Implementation-Vendor-Id>org.eclipse.ee4j.ejb</Implementation-Vendor-Id>
+                        <Specification-Vendor>${project.organization.name}</Specification-Vendor>
                     </instructions>
                 </configuration>
                 <executions>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -38,6 +38,17 @@
         <findbugs.exclude>exclude.xml</findbugs.exclude>
         <findbugs.threshold>Low</findbugs.threshold>
         <legal.doc.source>../</legal.doc.source>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+        <spec-version-maven-plugin.version>2.1</spec-version-maven-plugin.version>
+        <maven-bundle-plugin.version>1.4.3</maven-bundle-plugin.version>
+        <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+        <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+        <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+        <jakarta.transaction-api.version>2.0.0-RC1</jakarta.transaction-api.version>
     </properties>
 
     <name>Jakarta Enterprise Beans</name>
@@ -64,7 +75,7 @@
     <licenses>
         <license>
             <name>EPL 2.0</name>
-            <url>http://www.eclipse.org/legal/epl-2.0</url>
+            <url>https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.html</url>
             <distribution>repo</distribution>
         </license>
         <license>
@@ -97,32 +108,32 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>${maven-compiler-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>spec-version-maven-plugin</artifactId>
-                    <version>2.1</version>
+                    <version>${spec-version-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>1.4.3</version>
+                    <version>${maven-bundle-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>${maven-jar-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>${maven-source-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>${maven-javadoc-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -132,12 +143,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.7.1</version>
+                    <version>${maven-site-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M2</version>
+                    <version>${maven-enforcer-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -146,8 +157,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -229,7 +240,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
+                    <source>${maven.compiler.source}</source>
+                    <doclint>none</doclint>
                     <bottom>
                         <![CDATA[<p align="left">Copyright &#169; 2018, ${current.year} Eclipse Foundation.<br>Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
                     </bottom>
@@ -350,15 +362,12 @@
                 </executions>
             </plugin>
         </plugins>
-
     </build>
-
     <dependencies>
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <version>2.0.0-RC1</version>
+            <version>${jakarta.transaction-api.version}</version>
         </dependency>
     </dependencies>
-
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -58,6 +58,7 @@
 
     <url>https://github.com/eclipse-ee4j/ejb-api</url>
     <organization>
+        <name>Eclipse Foundation</name>
         <url>https://projects.eclipse.org/projects/ee4j.ejb</url>
     </organization>
     <developers>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -40,14 +40,14 @@
         <legal.doc.source>../</legal.doc.source>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <spec-version-maven-plugin.version>2.1</spec-version-maven-plugin.version>
-        <maven-bundle-plugin.version>1.4.3</maven-bundle-plugin.version>
-        <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
-        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
-        <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
-        <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+        <maven-bundle-plugin.version>4.2.1</maven-bundle-plugin.version>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <maven-site-plugin.version>3.9.0</maven-site-plugin.version>
+        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <jakarta.transaction-api.version>2.0.0-RC1</jakarta.transaction-api.version>
     </properties>
 
@@ -215,7 +215,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
                     <excludes>
                         <exclude>**/*.java</exclude>
                     </excludes>
@@ -357,6 +359,29 @@
                         <configuration>
                             <name>current.year</name>
                             <pattern>yyyy</pattern>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.5.4</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>[1.8.0,)</version>
+                                    <message>You need JDK8 or higher</message>
+                                </requireJavaVersion>
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -53,8 +53,8 @@
         <jakarta.transaction-api.version>2.0.0-RC1</jakarta.transaction-api.version>
     </properties>
 
-    <name>Jakarta Enterprise Beans</name>
-    <description>Jakarta Enterprise Beans</description>
+    <name>Jakarta Enterprise Beans API</name>
+    <description>Jakarta Enterprise Beans API</description>
 
     <url>https://github.com/eclipse-ee4j/ejb-api</url>
     <organization>

--- a/assembly.xml
+++ b/assembly.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!--
+ 
+    Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ 
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+ 
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+ 
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ 
+-->
+
+<assembly>
+    <id>package</id>
+    <formats>
+    <format>zip</format>
+    </formats>
+    <baseDirectory>enterprise-beans/${spec.version}</baseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>target/staging</directory>
+            <outputDirectory></outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -26,19 +26,32 @@
     <name>Jakarta Enterprise Beans Parent</name>
     <description>Jakarta Enterprise Beans</description>
     <url>https://github.com/eclipse-ee4j/ejb-api</url>
-
+    <organization>
+        <name>Eclipse Foundation</name>
+        <url>https://projects.eclipse.org/projects/ee4j.ejb</url>
+    </organization>
+    <issueManagement>
+        <system>github</system>
+        <url>https://github.com/eclipse-ee4j/ejb-api/issues</url>
+    </issueManagement>
     <scm>
         <connection>scm:git:ssh://git@github.com/eclipse-ee4j/ejb-api.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/eclipse-ee4j/ejb-api.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/ejb-api/tree/${project.scm.tag}</url>
-      <tag>HEAD</tag>
+        <tag>HEAD</tag>
     </scm>
-
-    <modules>
-        <module>api</module>
-        <module>spec</module>
-    </modules>
-
+    <mailingLists>
+        <mailingList>
+            <name>Enterprise Beans developer discussions</name>
+            <post>mailto:ejb-dev@eclipse.org</post>
+            <subscribe>mailto:ejb-dev-request@eclipse.org?subject=subscribe</subscribe>
+            <unsubscribe>mailto:ejb-dev-request@eclipse.org?subject=unsubscribe</unsubscribe>
+            <archive>http://www.eclipse.org/lists/ejb-dev</archive>
+            <otherArchives>
+                <otherArchive>http://www.eclipse.org/lists/ejb-dev/maillist.rss</otherArchive>
+            </otherArchives>
+        </mailingList>
+    </mailingLists>
     <licenses>
         <license>
             <name>EPL 2.0</name>
@@ -48,6 +61,11 @@
         <license>
             <name>GPL2 w/ CPE</name>
             <url>https://www.gnu.org/software/classpath/license.html</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>EFSL 1.0</name>
+            <url>https://www.eclipse.org/legal/efsl.php</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -124,4 +142,8 @@
             </plugin>
         </plugins>
     </build>
+    <modules>
+        <module>api</module>
+        <module>spec</module>
+    </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <packaging>pom</packaging>
     <version>4.0.0-SNAPSHOT</version>
     <name>Jakarta Enterprise Beans Parent</name>
-    <description>Jakarta Enterprise Beans</description>
+    <description>Jakarta Enterprise Beans Parent</description>
     <url>https://github.com/eclipse-ee4j/ejb-api</url>
     <organization>
         <name>Eclipse Foundation</name>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,12 @@
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>${maven-resources-plugin.version}</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <nonFilteredFileExtensions>
+                        <nonFilteredFileExtension>pdf</nonFilteredFileExtension>
+                    </nonFilteredFileExtensions>
+                </configuration>
                 <executions>
                     <execution>
                         <id>copy-apidocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -19,24 +19,20 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.eclipse.ee4j.ejb-api</groupId>
-    <artifactId>ejb-api-parent</artifactId>
+    <groupId>jakarta.ejb</groupId>
+    <artifactId>jakarta.ejb-parent</artifactId>
     <packaging>pom</packaging>
     <version>4.0.0-SNAPSHOT</version>
-    <name>${extension.name} API</name>
+    <name>Jakarta Enterprise Beans Parent</name>
     <description>Jakarta Enterprise Beans</description>
     <url>https://github.com/eclipse-ee4j/ejb-api</url>
 
     <scm>
         <connection>scm:git:ssh://git@github.com/eclipse-ee4j/ejb-api.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/eclipse-ee4j/ejb-api.git</developerConnection>
-        <url>https://github.com/eclipse-ee4j/ejb-api</url>
+        <url>https://github.com/eclipse-ee4j/ejb-api/tree/${project.scm.tag}</url>
       <tag>HEAD</tag>
     </scm>
-
-    <properties>
-        <extension.name>jakarta.ejb</extension.name>
-    </properties>
 
     <modules>
         <module>api</module>
@@ -55,5 +51,76 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <spec.version>4.0</spec.version>
+        <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-resources-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-apidocs</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/staging/apidocs</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>api/target/apidocs</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>            
+                    </execution>
+                    <execution>
+                        <id>copy-spec</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/staging</outputDirectory>
+                            <resources>
+                                <resource>
+                                <directory>spec/target/generated-docs</directory>
+                                <includes>
+                                    <include>*.html</include>
+                                    <include>*.pdf</include>
+                                </includes>
+                                <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven-assembly-plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.site.skip>true</maven.site.skip>
         <spec.version>4.0</spec.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,6 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0.6</version>
-    </parent>
-
     <groupId>org.eclipse.ee4j.ejb-api</groupId>
     <artifactId>ejb-api-parent</artifactId>
     <packaging>pom</packaging>
@@ -43,11 +36,6 @@
 
     <properties>
         <extension.name>jakarta.ejb</extension.name>
-        <non.final>false</non.final>
-        <findbugs.version>3.0.5</findbugs.version>
-        <findbugs.exclude>exclude.xml</findbugs.exclude>
-        <findbugs.threshold>Low</findbugs.threshold>
-        <legal.doc.source>.</legal.doc.source>
     </properties>
 
     <modules>
@@ -58,7 +46,7 @@
     <licenses>
         <license>
             <name>EPL 2.0</name>
-            <url>http://www.eclipse.org/legal/epl-2.0</url>
+            <url>https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.html</url>
             <distribution>repo</distribution>
         </license>
         <license>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,10 +20,10 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jakarta.ejb</groupId>
     <artifactId>jakarta.ejb-spec</artifactId>
+    <version>4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta Enterprise Beans Specification</name>
     <description>Jakarta Enterprise Beans Specification</description>
-    <version>4.0-SNAPSHOT</version>
     <organization>
         <name>Eclipse Foundation</name>
         <url>https://projects.eclipse.org/projects/ee4j.ejb</url>
@@ -74,12 +74,10 @@
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
     </properties>
-
     <build>
         <defaultGoal>package</defaultGoal>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>${maven-enforcer-plugin.version}</version>
                 <executions>
@@ -213,14 +211,9 @@
                         <docinfo1>true</docinfo1>
                     </attributes>
                 </configuration>
-
             </plugin>
-
-            <!--
-                This is the rule that builds the zip file for download.
-            -->
+            <!-- This is the rule that builds the zip file for download. -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>${maven-assembly-plugin.version}</version>
                 <inherited>false</inherited>
@@ -240,9 +233,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>${maven-release-plugin.version}</version>
                 <configuration>
                     <tagNameFormat>@{project.version}</tagNameFormat>
                     <preparationGoals>clean,package</preparationGoals>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -22,6 +22,7 @@
     <artifactId>jakarta.ejb-spec</artifactId>
     <packaging>pom</packaging>
     <name>Jakarta Enterprise Beans Specification</name>
+    <description>Jakarta Enterprise Beans Specification</description>
     <version>4.0-SNAPSHOT</version>
     <licenses>
         <license>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -24,6 +24,10 @@
     <name>Jakarta Enterprise Beans Specification</name>
     <description>Jakarta Enterprise Beans Specification</description>
     <version>4.0-SNAPSHOT</version>
+    <organization>
+        <name>Eclipse Foundation</name>
+        <url>https://projects.eclipse.org/projects/ee4j.ejb</url>
+    </organization>
     <licenses>
         <license>
             <name>EFSL 1.0</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -62,7 +62,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <jruby.version>9.2.11.1</jruby.version>
@@ -209,7 +209,9 @@
                         <idprefix />
                         <idseparator>-</idseparator>
                         <docinfo1>true</docinfo1>
+                        <imagesdir>images</imagesdir>
                     </attributes>
+                    <sourceDirectory>src/main/asciidoc</sourceDirectory>
                 </configuration>
             </plugin>
             <!-- This is the rule that builds the zip file for download. -->

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -62,10 +62,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <asciidoctor.maven.plugin.version>1.6.0</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>1.6.2</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
-        <jruby.version>9.2.11.1</jruby.version>
+        <jruby.version>9.2.12.0</jruby.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -166,8 +166,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <sourceHighlighter>coderay</sourceHighlighter>
                     <attributes>
+                        <sourceHighlighter>coderay</sourceHighlighter>
                         <revnumber>${project.version}</revnumber>
                         <revremark>${status}</revremark>
                         <revdate>${revisiondate}</revdate>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -17,18 +17,44 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <parent>
-        <groupId>org.eclipse.ee4j.ejb-api</groupId>
-        <artifactId>ejb-api-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>enterprise-beans-spec</artifactId>
+    <groupId>jakarta.ejb</groupId>
+    <artifactId>jakarta.ejb-spec</artifactId>
     <packaging>pom</packaging>
     <name>Jakarta Enterprise Beans Specification</name>
     <version>4.0-SNAPSHOT</version>
-
+    <licenses>
+        <license>
+            <name>EFSL 1.0</name>
+            <url>https://www.eclipse.org/legal/efsl.php</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <issueManagement>
+        <system>github</system>
+        <url>https://github.com/eclipse-ee4j/ejb-api/issues</url>
+    </issueManagement>
+    <scm>
+        <connection>scm:git:ssh://git@github.com/eclipse-ee4j/ejb-api.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/eclipse-ee4j/ejb-api.git</developerConnection>
+        <url>https://github.com/eclipse-ee4j/ejb-api/tree/${project.scm.tag}</url>
+        <tag>HEAD</tag>
+    </scm>
+    <mailingLists>
+        <mailingList>
+            <name>Enterprise Beans developer discussions</name>
+            <post>mailto:ejb-dev@eclipse.org</post>
+            <subscribe>mailto:ejb-dev-request@eclipse.org?subject=subscribe</subscribe>
+            <unsubscribe>mailto:ejb-dev-request@eclipse.org?subject=unsubscribe</unsubscribe>
+            <archive>http://www.eclipse.org/lists/ejb-dev</archive>
+            <otherArchives>
+                <otherArchive>http://www.eclipse.org/lists/ejb-dev/maillist.rss</otherArchive>
+            </otherArchives>
+        </mailingList>
+    </mailingLists>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
@@ -37,6 +63,7 @@
         <jruby.version>9.2.11.1</jruby.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+        <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
@@ -206,6 +233,15 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.0.0-M1</version>
+                <configuration>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <preparationGoals>clean,package</preparationGoals>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -31,10 +31,12 @@
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.6.2</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.18</asciidoctorj.pdf.version>
-        <jruby.version>9.2.6.0</jruby.version>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
+        <jruby.version>9.2.11.1</jruby.version>
+        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
@@ -47,7 +49,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -56,6 +58,9 @@
                         </goals>
                         <configuration>
                             <rules>
+                                <requireMavenVersion>
+                                    <version>3.0.5</version>
+                                </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>[1.8.0,)</version>
                                     <message>You need JDK8 or higher</message>
@@ -185,7 +190,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>${maven-assembly-plugin.version}</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/spec/src/main/asciidoc/core/RuntimeEnvironment.adoc
+++ b/spec/src/main/asciidoc/core/RuntimeEnvironment.adoc
@@ -441,62 +441,45 @@ means that the container must be able to grant the permission, the term
 .Java SE Platform Security Policy for a Standard Enterprise Beans Container
 [cols=2, options=header]
 |===
-Permission name
-|
-Enterprise Beans Container policy
-|
-java.security.AllPermission
-|
-deny
-|
-java.awt.AWTPermission
-|
-deny
-|
-java.io.FilePermission
-|
-deny
-|
-java.net.NetPermission
-|
-deny
-|
-java.util.PropertyPermission
-|
-grant "*", "read"
+| Permission name
+| Enterprise Beans Container policy
 
+| java.security.AllPermission
+| deny
+
+| java.awt.AWTPermission
+| deny
+
+| java.io.FilePermission
+| deny
+
+| java.net.NetPermission
+| deny
+
+| java.util.PropertyPermission
+| grant "*", "read" +
 deny all other
-|
-java.lang.reflect.ReflectPermission
-|
-deny
-|
-java.lang.RuntimePermission
-|
-grant "queuePrintJob"
 
-grant "loadLibrary"
+| java.lang.reflect.ReflectPermission
+| deny
 
+| java.lang.RuntimePermission
+| grant "queuePrintJob" +
+grant "loadLibrary" +
 deny all other
-|
-java.io.FilePermission
-|
-grant "*", "read,write"
 
+| java.io.FilePermission
+| grant "*", "read,write" +
 deny all other
-|
-java.lang.SecurityPermission
 
-deny
-|
-java.io.SerializablePermission
+| java.lang.SecurityPermission
+| deny
 
-deny
-|
-java.net.SocketPermission
-|
-grant "*", "connect" <<a10342>>
+| java.io.SerializablePermission
+| deny
 
+| java.net.SocketPermission
+| grant "*", "connect" <<a10342>> +
 deny all other
 |===
 *Notes:* +

--- a/spec/src/main/asciidoc/opt/EJB2.1EntityBeanComponentContractForBeanManagedPersistence.adoc
+++ b/spec/src/main/asciidoc/opt/EJB2.1EntityBeanComponentContractForBeanManagedPersistence.adoc
@@ -1005,7 +1005,7 @@ The method arguments must be the same as the arguments of the matching `ejbCreat
 The `throws` clause may define arbitrary application specific exceptions, including the `jakarta.ejb.CreateException`.
 
 _Compatibility Note: Enterprise Beans 1.0 allowed the `ejbPostCreate` method to throw the `java.rmi.RemoteException` to indicate a non-application exception.
-This practice was deprecated in Enterprise Beans 1.1—an Enterprise Beans 1.1 or Enterprise Beans 2.0 or later compliant enterprise bean should throw the `jakarta.ejb.EJBException` or another `java.lang.RuntimeException` to indicate non-application exceptions to the container (see <<3221>>).
+This practice was deprecated in Enterprise Beans 1.1—an Enterprise Beans 1.1 or Enterprise Beans 2.0 or later compliant enterprise bean should throw the `jakarta.ejb.EJBException` or another `java.lang.RuntimeException` to indicate non-application exceptions to the container (see <<a3221>>).
 An Enterprise Beans 2.0 or later enterprise bean should not throw the `java.rmi.RemoteException` from the `ejbPostCreate` method._
 
 ==== ejbFind Methods

--- a/spec/src/main/asciidoc/opt/EJBQL-EJB2.1QueryLanguageForContainerManagedPersistenceQueryMethods.adoc
+++ b/spec/src/main/asciidoc/opt/EJBQL-EJB2.1QueryLanguageForContainerManagedPersistenceQueryMethods.adoc
@@ -57,7 +57,7 @@ An Enterprise Beans QL query is a string which consists of the following clauses
 
 In BNF syntax, an Enterprise Beans QL query is defined as:
 
-[bnf]
+[source]
 ----
 Enterprise Beans QL ::= select_clause from_clause [where_clause] [orderby_clause]
 ----
@@ -181,7 +181,7 @@ The domain of the query may be constrained by path expressions.
 Identification variables designate instances of a particular entity bean abstract schema type.
 The FROM clause can contain multiple identification variable declarations separated by a comma (,).
 
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 from_clause ::= *FROM* identification_variable_declaration
                         [, identification_variable_declaration]*
@@ -261,7 +261,7 @@ A collection member identification variable declaration can use the result of a 
 
 The Enterprise Beans QL syntax for declaring an identification variable as a range variable is similar to that of SQL; optionally, it uses the AS keyword.
 
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 range_variable_declaration ::= abstract_schema_name [*AS*] identifier
 ----
@@ -297,7 +297,7 @@ The argument to the IN operator is a collection-valued path expression.
 The path expression evaluates to a collection type specified as a result of navigation to a collection-valued cmr-field of an entity bean abstract schema type.
 
 The syntax for declaring a collection member identification variable is as follows:
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 collection_member_declaration ::= *IN* (collection_valued_path_expression) [*AS*] identifier
 ----
@@ -337,7 +337,7 @@ Path expression navigability is composed using "`inner join`" semantics.
 That is, if the value of a non-terminal cmr-field in the path expression is null, the path is considered to have no value, and does not participate in the determination of the result.
 
 The syntax for single-valued path expressions and collection valued path expressions is as follows:
-[bnf]
+[source]
 ----
 cmp_path_expression ::= 
         {identification_variable | single_valued_cmr_path_expression}.cmp_field
@@ -378,7 +378,7 @@ The WHERE clause of a query consists of a conditional expression used to select 
 The WHERE clause thus restricts the result of a query.
 
 A WHERE clause is defined as follows:
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 where_clause ::= *WHERE* conditional_expression
 ----
@@ -449,7 +449,7 @@ Arithmetic operations use numeric promotion.
 Standard bracketing `()` for ordering expression evaluation is supported.
 
 Conditional expressions are defined as follows:
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 conditional_expression ::= conditional_term | conditional_expression *OR* conditional_term
 conditional_term ::= conditional_factor | conditional_term *AND* conditional_factor
@@ -481,7 +481,7 @@ The following sections describe other operators used in specific expressions.
 ===== Between Expressions
 
 The syntax for the use of the comparison operator [NOT] BETWEEN in an conditional expression is as follows:
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 arithmetic_expression [*NOT*] *BETWEEN* arithmetic-expression *AND* arithmetic-expression
 ----
@@ -506,7 +506,7 @@ Examples are:
 ===== In Expressions
 
 The syntax for the use of the comparison operator [NOT] IN in a conditional expression is as follows:
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 cmp_path_expression [*NOT*] *IN* ( {literal | input_parameter} [, {literal | input_parameter}]* )
 ----
@@ -528,7 +528,7 @@ If the value of a `cmp_path_expression` in an IN or NOT IN expression is `NULL` 
 ===== Like Expressions
 
 The syntax for the use of the comparison operator [NOT] LIKE in a conditional expression is as follows:
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 cmp_path_expression [*NOT*] *LIKE* pattern_value [*ESCAPE* escape_character]
 ----
@@ -554,7 +554,7 @@ If the `escape_character` is specified and is `NULL`, the value of the LIKE expr
 ===== Null Comparison Expressions
 
 The syntax for the use of the comparison operator IS NULL in a conditional expression is as follows:
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 {single_valued_path_expression | input_parameter} *IS* [*NOT*] *NULL*
 ----
@@ -564,7 +564,7 @@ A null comparison expression tests whether or not the single-valued path express
 ===== Empty Collection Comparison Expressions
 
 The syntax for the use of the comparison operator IS EMPTY in an `empty_collection_comparison_expression` is as follows:
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 collection_valued_path_expression *IS* [*NOT*] *EMPTY*
 ----
@@ -592,7 +592,7 @@ If the value of the collection-valued path expression in an empty collection com
 The syntax for the use of the comparison operator MEMBER OF
 footnote:a3381[The use of the reserved word OF is optional in this expression.]
 in an `collection_member_expression` is as follows:
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 {single_valued_cmr_path_expression | identification_variable | input_parameter}
         [*NOT*] *MEMBER* [*OF*] collection_valued_path_expression
@@ -647,7 +647,7 @@ The SELECT clause contains either a single range variable that ranges over an en
 In the case of a finder method, the SELECT clause is restricted to contain either a single range variable or a single-valued path expression that evaluates to the abstract schema type of the entity bean for which the finder method is defined.
 
 The SELECT clause has the following syntax:
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 select_clause ::= *SELECT* [*DISTINCT*] {select_expression | *OBJECT* (identification_variable)}
 
@@ -772,7 +772,7 @@ AND l.price IS NOT NULL
 The ORDER BY clause allows the objects or values that are returned by the query to be ordered.
 
 The syntax of the ORDER BY clause is
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 orderby_clause ::= *ORDER BY* orderby_item [, orderby_item]*
 orderby_item ::= cmp_path_expression [*ASC* | *DESC*]
@@ -1170,7 +1170,7 @@ Enterprise Beans QL BNF notation summary:
 * *boldface* keywords
 
 The following is the complete BNF notation for Enterprise Beans QL:
-[bnf, subs="+quotes"]
+[source, subs="+quotes"]
 ----
 Enterprise Beans QL ::= select_clause from_clause [where_clause] [orderby_clause]
 

--- a/spec/src/main/asciidoc/opt/SupportForTransactions.adoc
+++ b/spec/src/main/asciidoc/opt/SupportForTransactions.adoc
@@ -34,7 +34,7 @@ The Bean Provider of an enterprise bean with container-managed transaction demar
 A transaction attribute is a value associated with a method of an entity bean’s home or component interface.
 
 The transaction attributes are specified for the methods defined in the bean’s component interface and all the direct and indirect superinterfaces of the component interface, excluding the `getEJBHome`, `getEJBLocalHome`, `getHandle`, `getPrimaryKey`, and `isIdentical` methods; for the methods defined in the bean’s home interface and all the direct and indirect superinterfaces of the home interface, excluding the `getEJBMetaData` and `getHomeHandle` methods specific to the remote home interface; and for the timeout callback methods, if any.
-footnote:<<a3394>>[Note that the deployment descriptor must be used to specify transaction attributes for entity bean methods if the transaction attribute is not `Required` (the default value)]
+footnote:a3394[Note that the deployment descriptor must be used to specify transaction attributes for entity bean methods if the transaction attribute is not `Required` (the default value)]
 
 For entity beans that use container-managed persistence, only the `Required`, `RequiresNew`, or `Mandatory` deployment descriptor transaction attribute values should be used for the methods defined in the bean’s component interface and all the direct and indirect superinterfaces of the component interface, excluding the `getEJBHome`, `getEJBLocalHome`, `getHandle`, `getPrimaryKey`, and `isIdentical` methods; and for the methods defined in the bean’s home interface and all the direct and indirect superinterfaces of the home interface, excluding the `getEJBMetaData` and `getHomeHandle` methods specific to the remote home interface.
 


### PR DESCRIPTION
The following changes are made in this PR:

**[parent]**
- Remove ee4j parent
- Change groupId from org.eclipse.ee4j.ejb-api to jakarta.ejb
- Change artifactId from ejb-api-parent to jakarta.ejb-parent
- Create zip archive with apidocs and specification documents

**[api]**
- Change hard-coded values to properties
- Update plugin versions to latest release
- Update project information, add mailing list
- Replace findbugs with spotbugs maven plugin
- Fix "mvn site"
- Configure spotbugs and javadoc reports
- Set minimum maven version to 3.5.4 (minimum required for spec-version-maven-plugin)
- Move javadoc configuration to plugin management (shared by build and reporting)

**[spec]**
- Remove ejb-api-parent
- Change groupId from org.eclipse.ee4j.ejb-api to jakarta.ejb
- Change artifactId from enterprise-beans-spec to jakarta.ejb-spec
- Add project information, organization, scm, issueManagement, mailingList and licenses
- Update plugin versions to latest release
- Set minimum maven version to 3.0.5
- Add maven-release-plugin to prepare project for final release
- Fix errors and warning during build
 - Table in core/RuntimeEnvironment.adoc
 - Broken reference in opt/EJB2.1EntityBeanComponentContractForBeanManagedPersistence.adoc
 - Change bnf to source in opt/EJBQL-EJB2.1QueryLanguageForContainerManagedPersistenceQueryMethods.adoc
 - Broken footnote in opt/SupportForTransactions.adoc