### PR TITLE
Reflect that @Schedule is now a repeatable annotation

### DIFF
--- a/spec/src/main/asciidoc/core/Introduction.adoc
+++ b/spec/src/main/asciidoc/core/Introduction.adoc
@@ -35,6 +35,8 @@ application programmer._
 
 * _Marked the EJB 2.x API Group as "Optional"_
 
+* _@Schedule annotation is now repeatable_
+
 === What was New in Enterprise Beans 3.2
 
 The Enterprise Beans 3.2 <<a9891>> architecture

--- a/spec/src/main/asciidoc/core/RevisionHistory.adoc
+++ b/spec/src/main/asciidoc/core/RevisionHistory.adoc
@@ -14,6 +14,7 @@ Document updates in preparation for EJB 4.0:
 - Removed the methods relying on JAX-RPC link:Ejb.html#a608[See Session Bean Component Contract]
 - Removed the deprecated EJBContext.getEnvironment() method link:Ejb.html#a3613[See Enterprise Bean Environment]
 - Marked the EJB 2.x API Group as "Optional" link:Ejb.html#a9423[See Runtime Environment]
+- @Schedule now a repeatable annotation
 
 Removed documents in preparation for EJB 4.0:
 

--- a/spec/src/main/asciidoc/core/TimerService.adoc
+++ b/spec/src/main/asciidoc/core/TimerService.adoc
@@ -455,6 +455,18 @@ single timeout callback method using the `Schedules` annotation.
 public void sendLunchNotification() { ... }
 ----
 
+Alternatively, as of Enterprise Beans 4.0 multiple automatic timers
+can be applied to a single timeout callback method using `Schedule`
+as a repeatable annotation.
+
+*Example:*
+[source, java]
+----
+@Schedule(hour="12", dayOfWeek="Mon-Thu")
+@Schedule(hour="11", dayOfWeek="Fri")
+public void sendLunchNotification() { ... }
+----
+
 A `Schedule` annotation can optionally
 specify an info string. This string can be retrieved by calling
 `Timer.getInfo()` on the associated Timer object. If no `info` string is


### PR DESCRIPTION
Minor edits to reflect that the `Schedule` annotation is now repeatable.