### PR TITLE
Prefix jakarta to specification document 

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jakarta.ejb</groupId>
     <artifactId>jakarta.ejb-spec</artifactId>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.0</version>
     <packaging>pom</packaging>
     <name>Jakarta Enterprise Beans Specification</name>
     <description>Jakarta Enterprise Beans Specification</description>
@@ -73,6 +73,7 @@
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
+        <docversion>4.0-draft</docversion>
     </properties>
     <build>
         <defaultGoal>package</defaultGoal>
@@ -132,7 +133,7 @@
                         <configuration>
                             <backend>html5</backend>
                             <sourceDocumentName>enterprise-beans-spec-core.adoc</sourceDocumentName>
-                            <outputFile>${project.build.directory}/generated-docs/enterprise-beans-spec-core-${project.version}.html</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-enterprise-beans-spec-core-${docversion}.html</outputFile>
                             <attributes>
                                 <toc>left</toc>
                             </attributes>
@@ -148,7 +149,7 @@
                         <configuration>
                             <backend>pdf</backend>
                             <sourceDocumentName>enterprise-beans-spec-core.adoc</sourceDocumentName>
-                            <outputFile>${project.build.directory}/generated-docs/enterprise-beans-spec-core-${project.version}.pdf</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-enterprise-beans-spec-core-${docversion}.pdf</outputFile>
                             <attributes>
                                 <pdf-stylesdir>${project.basedir}/src/main/theme</pdf-stylesdir>
                                 <pdf-style>jakartaee</pdf-style>
@@ -168,7 +169,7 @@
                         <configuration>
                             <backend>html5</backend>
                             <sourceDocumentName>enterprise-beans-spec-opt.adoc</sourceDocumentName>
-                            <outputFile>${project.build.directory}/generated-docs/enterprise-beans-spec-opt-${project.version}.html</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-enterprise-beans-spec-opt-${docversion}.html</outputFile>
                             <attributes>
                                 <toc>left</toc>
                             </attributes>
@@ -184,7 +185,7 @@
                         <configuration>
                             <backend>pdf</backend>
                             <sourceDocumentName>enterprise-beans-spec-opt.adoc</sourceDocumentName>
-                            <outputFile>${project.build.directory}/generated-docs/enterprise-beans-spec-opt-${project.version}.pdf</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-enterprise-beans-spec-opt-${docversion}.pdf</outputFile>
                             <attributes>
                                 <pdf-stylesdir>${project.basedir}/src/main/theme</pdf-stylesdir>
                                 <pdf-style>jakartaee</pdf-style>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jakarta.ejb</groupId>
     <artifactId>jakarta.ejb-spec</artifactId>
-    <version>4.0</version>
+    <version>4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta Enterprise Beans Specification</name>
     <description>Jakarta Enterprise Beans Specification</description>
@@ -73,7 +73,8 @@
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
-        <docversion>4.0-draft</docversion>
+        <spec.version>4.0</spec.version>
+        <docversion>${spec.version}-draft</docversion>
     </properties>
     <build>
         <defaultGoal>package</defaultGoal>
@@ -199,7 +200,7 @@
                 <configuration>
                     <attributes>
                         <sourceHighlighter>coderay</sourceHighlighter>
-                        <revnumber>${project.version}</revnumber>
+                        <revnumber>${spec.version}</revnumber>
                         <revremark>${status}</revremark>
                         <revdate>${revisiondate}</revdate>
                         <doctype>book</doctype>

--- a/spec/src/main/asciidoc/core/Introduction.adoc
+++ b/spec/src/main/asciidoc/core/Introduction.adoc
@@ -28,22 +28,22 @@ prior Enterprise Beans specifications delivering a namespace change
 from `javax` to `jakarta` across the API along with removal of
 deprecated APIs.
 
-* _All `javax.ejb` namespace/packages have been renamed to `jakarta.ejb`_
+* _All `javax.ejb` namespace/packages have been renamed to `jakarta.ejb`._
 
-* _Removed the methods relying on java.security.Identity which has
+* _Removed the methods relying on `java.security.Identity` which has
 been removed from the Java 14._
 
-* _Removed the methods relying on JAX-RPC to reflect the removal of
-JAX-RPC from the Jakarta EE 9 Platform._
+* _Removed the methods relying on Jakarta XML RPC to reflect the removal of
+XML RPC from the Jakarta EE 9 Platform._
 
-* _Removed the deprecated EJBContext.getEnvironment() method._
+* _Removed the deprecated `EJBContext.getEnvironment()` method._
 
-* _Removed the Support for Distributed Interoperability to reflect
+* _Removed the "`Support for Distributed Interoperability`" to reflect
 the removal of CORBA from Java 11 and the Jakarta EE 9 Platform._
 
-* _Marked the EJB 2.x API Group as "Optional"_
+* _Marked the Enterprise Beans 2.x API Group as "Optional"._
 
-* _@Schedule annotation is now repeatable_
+* _``@Schedule`` annotation is now repeatable._
 
 === What was New in Jakarta Enterprise Beans 3.2
 

--- a/spec/src/main/asciidoc/core/RevisionHistory.adoc
+++ b/spec/src/main/asciidoc/core/RevisionHistory.adoc
@@ -2,23 +2,32 @@
 [[a9892]]
 == Revision History
 
-This appendix lists the significant changes
-that have been made to this document during the development of the EJB
-4.0 Specification.
+This appendix lists the significant changes that have been made to this
+document during the development of the Enterprise Beans 4.0
+Specification.
 
 === Public Draft
 
-Document updates in preparation for EJB 4.0:
+Document updates in preparation for Enterprise Beans 4.0:
 
-- Removed the methods relying on java.security.Identity link:Ejb.html#a4945[See Security Management]
-- Removed the methods relying on JAX-RPC link:Ejb.html#a608[See Session Bean Component Contract]
-- Removed the deprecated EJBContext.getEnvironment() method link:Ejb.html#a3613[See Enterprise Bean Environment]
-- Marked the EJB 2.x API Group as "Optional" link:Ejb.html#a9423[See Runtime Environment]
-- @Schedule now a repeatable annotation
+- Removed the methods relying on `java.security.Identity` <<a4945, See
+Security Management>>
 
-Removed documents in preparation for EJB 4.0:
+- Removed the methods relying on Jakarta XML RPC <<a608, See Session
+Bean Component Contract>>
 
-- Support for Distributed Interoperability
+- Removed the deprecated `EJBContext.getEnvironment()` method <<a3613,
+See Enterprise Bean Environment>>
+
+- Marked the Enterprise Beans 2.x API Group as "Optional" <<a9423, See
+Runtime Environment>>
+
+- `@Schedule` now a repeatable annotation <<automatic-timer-creation,
+See Automatic Timer Creation>>
+
+Removed documents in preparation for Enterprise Beans 4.0:
+
+- "`Support for Distributed Interoperability`"
 
 === Final Release Candidate
 

--- a/spec/src/main/asciidoc/enterprise-beans-spec-core.adoc
+++ b/spec/src/main/asciidoc/enterprise-beans-spec-core.adoc
@@ -2,9 +2,9 @@
 // Copyright (c) 2017, 2020 Contributors to the Eclipse Foundation
 //
 
-= Jakarta Enterprise Beans, Core Features
+= Jakarta(R) Enterprise Beans, Core Features
 :authors: Jakarta Enterprise Beans Team, https://projects.eclipse.org/projects/ee4j.ejb
-:email: https://dev.eclipse.org/mailman/listinfo/ejb-api-dev
+:email: https://accounts.eclipse.org/mailing-list/ejb-dev
 :version-label!:
 :doctype: book
 :license: Eclipse Foundation Specification License v1.0

--- a/spec/src/main/asciidoc/enterprise-beans-spec-opt.adoc
+++ b/spec/src/main/asciidoc/enterprise-beans-spec-opt.adoc
@@ -2,9 +2,9 @@
 // Copyright (c) 2017, 2020 Contributors to the Eclipse Foundation
 //
 
-= Jakarta Enterprise Beans, Optional Features
+= Jakarta(R) Enterprise Beans, Optional Features
 :authors: Jakarta Enterprise Beans Team, https://projects.eclipse.org/projects/ee4j.ejb
-:email: https://dev.eclipse.org/mailman/listinfo/ejb-api-dev
+:email: https://accounts.eclipse.org/mailing-list/ejb-dev
 :version-label!:
 :doctype: book
 :license: Eclipse Foundation Specification License v1.0


### PR DESCRIPTION
The idea behind this PR to enable tagging of specific commit to release a version of the specification in a repeatable manner.

For example, if we want to release a Public Draft 2 then the properties should be set as shown below:
status = PUBLIC DRAFT 2
revisiondate = August 25, 2020
docversion = 4.0-pd2

Running `mvn clean package` will yield 

- jakarta-enterprise-beans-spec-core-4.0-pd2.html
- jakarta-enterprise-beans-spec-core-4.0-pd2.pdf
- jakarta-enterprise-beans-spec-opt-4.0-pd2.html
- jakarta-enterprise-beans-spec-opt-4.0-pd2.pdf

Step 1: Commit the changes
Step 2: Create a tag 4.0-pd2 
Step 3: Revert the changes
Step 4: Create a PR 

It would be awesome if this could be automated via Jenkins.

Other changes included in this PR are minor corrections:

- Update the mailing list URL
- Add registered mark after Jakarta in title
- Replace JAX-RPC with Jakarta XML RPC
- Replace EJB 2.x with Enterprise Beans 2.x